### PR TITLE
Fix Gemma3 examples

### DIFF
--- a/litert_torch/generative/examples/gemma3/README.md
+++ b/litert_torch/generative/examples/gemma3/README.md
@@ -57,8 +57,8 @@ config = bundler.BundleConfig(
     start_token=START_TOKEN,
     stop_tokens=STOP_TOKENS,
     output_filename="/tmp/gemma3.task",
-    prompt_prefix="<start_of_turn>user\n",
-    prompt_suffix="<end_of_turn>\n<start_of_turn>model\n",
+    prompt_prefix_user="<start_of_turn>user\n",
+    prompt_suffix_user="<end_of_turn>\n<start_of_turn>model\n",
 )
 bundler.create_bundle(config)
 ```

--- a/litert_torch/generative/examples/gemma3/convert_gemma3_to_tflite.py
+++ b/litert_torch/generative/examples/gemma3/convert_gemma3_to_tflite.py
@@ -38,7 +38,9 @@ def main(_):
   else:
     raise ValueError(f'Unsupported model size: {_MODEL_SIZE.value}')
 
-  converter.build_and_convert_to_tflite_from_flags(model_builder)
+  output_name_prefix = f'gemma3-{_MODEL_SIZE.value}'  
+
+  converter.build_and_convert_to_tflite_from_flags(model_builder, output_name_prefix=output_name_prefix)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The filename now contains the actual model size, otherwise the filename is always gemma3-1b.
The MediaPipe API for task conversion has changed, hence I am updating the README. 