### PR TITLE
Preserve dict keys in flat_arg_names for positional args

### DIFF
--- a/litert_torch/_convert/signature.py
+++ b/litert_torch/_convert/signature.py
@@ -49,16 +49,16 @@ class Signature:
   @property
   def flat_arg_names(self) -> list[str]:
     spec = pytree.tree_flatten(self._normalized_sample_args_kwargs)[1]
-    args_spec, kwargs_spec = spec.children_specs
-    names = []
-    for i in range(args_spec.num_leaves):
-      names.append(f"args_{i}")
+    args_spec, kwargs_spec = spec.children()
+    args_names = backend.export_utils.flat_dict_names(
+        args_spec.children(), args_spec.context
+    )
+    args_names = [f"args_{name}" for name in args_names]
 
     kwargs_names = backend.export_utils.flat_dict_names(
-        kwargs_spec.children_specs, kwargs_spec.context
+        kwargs_spec.children(), kwargs_spec.context
     )
-    names.extend(kwargs_names)
-    return names
+    return args_names + kwargs_names
 
   @property
   def flat_args(self) -> tuple[Any, ...]:

--- a/litert_torch/backend/export_utils.py
+++ b/litert_torch/backend/export_utils.py
@@ -28,7 +28,7 @@ IR_DYNAMIC = -9223372036854775808
 
 
 def flat_dict_names(
-    tree_spec: pytree.TreeSpec, context: pytree.Context
+    tree_spec: list[pytree.TreeSpec], context: pytree.Context
 ) -> list[str]:
   """Given a TreeSpec, this produces a list of names for the leaves.
 
@@ -59,17 +59,17 @@ def flat_dict_names(
   flat_names = []
   if context is None:
     for i, spec in enumerate(tree_spec):
-      if spec.children_specs:
+      if spec.children():
         flat_names.extend([
             f"{i}_{name}"
-            for name in flat_dict_names(spec.children_specs, spec.context)
+            for name in flat_dict_names(spec.children(), spec.context)
         ])
       else:
         flat_names.append(f"{i}")
   else:
     flat_ctx = _flatten_list(context)
     for prefix, spec in zip(flat_ctx, tree_spec):
-      leaf_flat_names = flat_dict_names(spec.children_specs, spec.context)
+      leaf_flat_names = flat_dict_names(spec.children(), spec.context)
       if leaf_flat_names:
         flat_names.extend([f"{prefix}_{name}" for name in leaf_flat_names])
       else:


### PR DESCRIPTION
**Problem**
When a `torch.nn.Module` accepts a `dict` as a positional forward argument, `litert_torch.convert` flattens the dict values but renames them to generic `args_0`, `args_1`, etc. This loses the original dict keys that `torch.export.export` preserves.

In addition, the codebase uses the deprecated `treespec.children_specs` API which emits `FutureWarning` on PyTorch 2.6+.

**Fixes in this PR**
1. **Preserve dict keys in `flat_arg_names`** (`signature.py`)
   - Uses `flat_dict_names` for positional args too (with an `args_` prefix), so dict keys are preserved.
   - Simple tensor positional args still produce `args_0`, `args_1` (backward compatible).

2. **Fix deprecated pytree API usage** (`export_utils.py`, `litert_converter.py`)
   - Replaces all `treespec.children_specs` with `treespec.children()`.

3. **Guard `in_i32` against non-integer args** (`export.py`)
   - When dynamic shapes are present, `arange` ops may have symbolic `start`/`end` values. The helper now skips the rewrite gracefully instead of crashing with `TypeError`.

4. **Fail fast on `dynamic_shapes`** (`interface.py`)
   - The JAX-based lowering path does not yet support dynamic dimensions. Rather than crashing with obscure JAX assertion errors, `convert()` now raises a clear `NotImplementedError` pointing to issue #870.

Fixes #1022
Related to #870