### PR TITLE
Map ui8 result type back to torch.uint8 in ir_element_type_to_torch_dtype

### DIFF
--- a/litert_torch/backend/export_utils.py
+++ b/litert_torch/backend/export_utils.py
@@ -212,10 +212,10 @@ def ir_element_type_to_torch_dtype(ty):
   if isinstance(ty, ir.F16Type):
     return torch.half
   if isinstance(ty, ir.IntegerType):
+    if ty.is_unsigned:
+      if ty.width == 8:
+        return torch.uint8
     if ty.is_signless:
-      if ty.is_unsigned:
-        if ty.width == 8:
-          return torch.uint8
       if ty.width == 64:
         return torch.long
       if ty.width == 32:

--- a/litert_torch/backend/test/test_export_utils.py
+++ b/litert_torch/backend/test/test_export_utils.py
@@ -1,0 +1,61 @@
+# Copyright 2024 The LiteRT Torch Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""export_utils related tests."""
+
+from litert_torch import backend
+from litert_converter.mlir import ir
+import torch
+
+from absl.testing import absltest as googletest
+from absl.testing import parameterized
+
+
+class TestDtypeMapping(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      ("uint8", torch.uint8),
+      ("int16", torch.int16),
+      ("int32", torch.int32),
+      ("long", torch.long),
+      ("bool", torch.bool),
+      ("half", torch.half),
+      ("float32", torch.float32),
+      ("float64", torch.float64),
+  )
+  def test_torch_dtype_ir_element_type_round_trip(self, torch_dtype):
+    with backend.export_utils.create_ir_context(), ir.Location.unknown():
+      ir_type = backend.export_utils.torch_dtype_to_ir_element_type(torch_dtype)
+      self.assertEqual(
+          backend.export_utils.ir_element_type_to_torch_dtype(ir_type),
+          torch_dtype,
+      )
+
+  def test_uint8_maps_to_unsigned_integer(self):
+    # Regression test: a torch.uint8 result type must map back to torch.uint8.
+    # ir_element_type_to_torch_dtype used to nest the unsigned check under
+    # `is_signless`, which is never true for an unsigned integer type, so a
+    # `ui8` type fell through and raised "Unsupported ir element type".
+    with backend.export_utils.create_ir_context(), ir.Location.unknown():
+      ir_type = backend.export_utils.torch_dtype_to_ir_element_type(torch.uint8)
+      self.assertTrue(ir_type.is_unsigned)
+      self.assertEqual(ir_type.width, 8)
+      self.assertEqual(
+          backend.export_utils.ir_element_type_to_torch_dtype(ir_type),
+          torch.uint8,
+      )
+
+
+if __name__ == "__main__":
+  googletest.main()


### PR DESCRIPTION
## Summary

`deef131e` ("Add support for torch.uint8 dtype.") added the forward
`torch.uint8 -> IntegerType.get_unsigned(8)` mapping, but the reverse mapping in
`ir_element_type_to_torch_dtype` was left broken: the `torch.uint8` branch is
nested under `if ty.is_signless:`, and an unsigned integer type has
`is_signless == False`, so the branch is unreachable. A `ui8` type therefore
falls through to `RuntimeError: Unsupported ir element type: ui8` — reached e.g.
via `jax_bridge/utils.py`, which maps bridged-op result types back to torch
dtypes. Background and a minimal repro are in #1060.

## Fix

Lift the unsigned check to be a sibling of the `is_signless` check, so a `ui8`
type maps back to `torch.uint8`. This completes the reverse direction of the
`torch.uint8` support added in `deef131e`.

## Test

Adds `litert_torch/backend/test/test_export_utils.py`:
- a parameterized `torch_dtype <-> ir element type` round-trip across all
  supported dtypes (including uint8);
- an explicit `ui8 -> torch.uint8` regression.

Verified: on `main` the new tests fail with `Unsupported ir element type: ui8`;
with this change they pass.

Refs #1060
