### PR TITLE
fix: lora out-dims for gqa/mha models (num_query_groups factor)

### DIFF
--- a/litert_torch/generative/layers/lora.py
+++ b/litert_torch/generative/layers/lora.py
@@ -293,8 +293,14 @@ class LoRA:
           block_config.attn_config.num_heads
           // block_config.attn_config.num_query_groups
       )
-      q_out_dim = q_per_kv * block_config.attn_config.head_dim
-      k_out_dim = v_out_dim = block_config.attn_config.head_dim
+      q_out_dim = (
+          block_config.attn_config.num_heads
+          * block_config.attn_config.head_dim
+      )
+      k_out_dim = v_out_dim = (
+          block_config.attn_config.num_query_groups
+          * block_config.attn_config.head_dim
+      )
       attention_lora = AttentionLoRA(
           query=LoRAWeight(
               a_prime=tensor_generator((config.embedding_dim, rank), dtype),


### PR DESCRIPTION
fixes #1066.

`LoRA._from_tensor_generator` computes the q/k/v lora out-dims without the `num_query_groups` factor that `CausalSelfAttention` uses when it builds q/k/v, so `apply_lora(...).reshape(q.shape)` fails during `torch.export` for any `num_query_groups != 1` — i.e. all grouped-query-attention models (qwen2.5/qwen3, llama-3, gemma-2/3, phi-3, …) and full mha. only mqa (`num_query_groups == 1`) works today, which is the single case `test_lora.py` covers, so it went unnoticed.

this builds the lora out-dims with the same factors attention uses:

- `q_out_dim = num_heads * head_dim`
- `k_out_dim = v_out_dim = num_query_groups * head_dim`

equivalent to the previous code when `num_query_groups == 1`, so the currently-working mqa path is unchanged.

verified by running `CausalSelfAttention.forward` with a non-`None` lora entry across mha/gqa/mqa and both `qkv_transpose_before_split` settings: before → gqa and mha fail with `RuntimeError: shape '[1, 256, 2, 1024]' is invalid for input of size 262144`; after → all pass, and mqa still passes. full repro in #1066.

note: `test_lora.py` only exercises `num_heads=1, num_query_groups=1`; a regression test with `num_query_groups > 1` would guard this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
