### PR TITLE
Keep attention QKV-unpack view chain within rank 4 for the GPU delegate

### DIFF
--- a/litert_torch/_convert/fx_passes/test/test_reduce_view_rank_pass.py
+++ b/litert_torch/_convert/fx_passes/test/test_reduce_view_rank_pass.py
@@ -126,6 +126,26 @@ class TestReduceViewRankPass(googletest.TestCase):
     self.assertLessEqual(max_rank, 4)
     torch.testing.assert_close(result.graph_module(x), f(x))
 
+  def test_permute_with_second_user_is_not_folded(self):
+    # The permute output forks to a second consumer besides the squeeze, so
+    # the rank-5 chain must stay alive for that branch; the pass backs off.
+    def f(x):  # x: (2, 1, 3, 4)
+      y = torch.unsqueeze(x, 0)  # (1, 2, 1, 3, 4)
+      y = torch.permute(y, [1, 0, 2, 3, 4])  # (2, 1, 1, 3, 4)
+      z = torch.squeeze(y, 1)  # (2, 1, 3, 4)
+      return z, torch.sum(y)  # second user of the permute
+
+    x = torch.randn(2, 1, 3, 4)
+    graph_module = make_fx(f, tracing_mode="fake")(x)
+    targets_before = [n.target for n in graph_module.graph.nodes]
+
+    result = fx_passes.ReduceViewRankPass()(graph_module)
+
+    self.assertFalse(result.modified)
+    targets_after = [n.target for n in result.graph_module.graph.nodes]
+    self.assertEqual(targets_before, targets_after)
+    torch.testing.assert_close(result.graph_module(x), f(x))
+
   def test_provenance_meta_copied_to_new_nodes(self):
     # The folded permute/squeeze nodes must carry the debug provenance of the
     # squeeze node they replace.


### PR DESCRIPTION
## Summary

A model that uses `torch.nn.MultiheadAttention` for self-attention — which also
covers PyTorch's built-in `nn.TransformerEncoder` / `nn.TransformerEncoderLayer`,
and e.g. CLIP / OpenCLIP — converts to a `.tflite` whose desktop op-set looks fine,
but on the **ML Drift GPU delegate (`LITERT_CL`)** the whole `CompiledModel` fails
to compile.

Root cause: torch's `_in_projection_packed` unpacks the packed QKV projection
with an `unsqueeze -> permute -> squeeze` view chain that **transiently
materializes rank-5 tensors**, even though the inserted dimension is size 1 and
is removed again immediately. ML Drift caps tensors at rank 4, so these
transient rank-5 `RESHAPE`/`TRANSPOSE` intermediates push every attention block
off the GPU and the partitioner cannot place the graph. There is no CPU fallback
in `CompiledModel(Accelerator.GPU)`, so the model never loads:

```
E tflite : Following operations are not supported by GPU delegate:
E tflite : RESHAPE: Tensor "...MultiheadAttention_attn;3" has bad input dims size: 5.
E tflite : RESHAPE: Tensor "...MultiheadAttention_attn;4" has bad input dims size: 5.
I tflite : Replacing 65 out of 751 node(s) with delegate (LITERT_CL) node ...
E litert : Failed to create compiled model: Failed to compile model
```

## The fix

`unsqueeze`, `permute` and `squeeze` are all pure metadata views, so the chain
`squeeze(permute(unsqueeze(x, d), perm), sq_dims)` is **exactly equal to a single
`permute` of `x`** (optionally followed by a `squeeze` of any other unit dims),
which never exceeds the rank of `x`.

This PR adds `ReduceViewRankPass`, which performs that algebraic folding. It is a
numerical no-op, and it **only fires when the `unsqueeze` actually inflates a
tensor past rank 4**, so graphs that are already within the rank-4 cap are left
untouched.

After this pass, stock `nn.MultiheadAttention` converts with **max tensor rank 4
(was 5, two rank-5 tensors)** on the generic `litert_torch.convert` path, with no
model-side change.

## Verification (reproduced on `main` HEAD `771c7bb`)

A tiny `nn.MultiheadAttention` model, converted via `litert_torch.convert` and
inspected with `ai_edge_litert.Interpreter`:

| | max tensor rank | #tensors rank>4 |
|---|---|---|
| before | 5 | 2 |
| after  | 4 | 0 |

- **Numerically exact:** the converted `.tflite` matches eager PyTorch to
  `max|diff| ≈ 1e-7` (float32 conversion noise) across `batch_first` True/False,
  multiple head/embed sizes, batch>1, and stacked attention blocks.
- **No regression:** a non-attention conv net is byte-for-byte unaffected (the
  pass does not fire); `litert_torch/_convert/test/test_convert.py` passes (26
  tests). A new `test_reduce_view_rank_pass.py` covers the fold, the numeric
  equivalence, `batch_first=False`, the multi-unit-dim squeeze branch, and the
  no-op case.

### On the full CLIP ViT-B/32 encoder

Converting the real **open_clip ViT-B/32** visual encoder through
`litert_torch.convert` (same path, same `main` HEAD):

| | max tensor rank | #tensors rank>4 |
|---|---|---|
| before | 5 | **24** (the two packed-QKV reshapes per `ResidualAttentionBlock`, ×12) |
| after  | 4 | **0** |

The 24 rank-5 tensors before the fix are exactly the ones the GPU delegate
rejects — they carry names like
`...ResidualAttentionBlock_0/...MultiheadAttention_attn;1` / `;2`, shapes
`(3,50,1,1,768)` / `(1,50,1,3,768)`. The pass removes all of them and the encoder
output stays faithful (`max|diff| ≈ 2.6e-6` tflite vs eager).

## On-device measurement (Pixel 8a, LITERT_CL / ML Drift)

I converted the pretrained (`openai`) open_clip ViT-B/32 image encoder twice — once
on pristine `main` HEAD and once with this PR, both with **stock
`nn.MultiheadAttention` and no model-side attention rewrite** — and loaded each on a
Pixel 8a via the LiteRT `CompiledModel(Accelerator.GPU)` path. The two `.tflite`s are
identical except for the litert-torch version:

| litert-torch | GPU delegate (`LITERT_CL`) | `CompiledModel(GPU)` |
|---|---|---|
| `main` HEAD (before) | `Replacing 65 out of 751 node(s) … 2 partitions`, then `RESHAPE … has bad input dims size: 5` on `ResidualAttentionBlock_*/…MultiheadAttention` | **Failed to compile model** → CPU fallback |
| this PR (after) | `Replacing 739 out of 739 node(s) … 1 partition` | **GPU ready** (whole encoder on the GPU) |

So the rank-4 attention lowering **alone** flips the encoder from "can't compile on
the GPU delegate" to "entire graph delegated", with no NHWC/layout change. (The node
totals differ — 751 vs 739 — because the pass removes the redundant
unsqueeze/permute/squeeze ops.) The fixed encoder also still classifies correctly
end-to-end (zero-shot top-1 matches stock CLIP), so it's GPU-clean *and* faithful.

## Surface question

I went with a dedicated FX pass because the rank-5 comes from a **multi-op view
chain** (torch's packed-QKV unpack), not a single decomposable aten op, so the
per-op composite/decomp-table mechanisms don't apply cleanly here. I placed it
right after `CanonicalizePass` in `_run_convert_passes`.

If you'd prefer a different surface (e.g. folding this into `CanonicalizePass`,
or a narrower/broader matcher), I'm happy to reshape it — just let me know which
you'd like.

**Scope note (what this does and does not cover):** this folds the rank-5 chain
that torch's `nn.MultiheadAttention` packed-QKV projection emits
(`unsqueeze → permute → squeeze`). Verified covered: `nn.MultiheadAttention`
self-attention and PyTorch's `nn.TransformerEncoder`/`nn.TransformerEncoderLayer`.
Already fine (no rank-5, untouched): attentions that project q/k/v separately and
split per head with `view(B, N, H, d).transpose(...)` (the typical HF-transformers
shape). **Not yet covered:** attentions that build packed QKV with a manual reshape
— `qkv.reshape(B, N, 3, H, d).permute(...).unbind(0)`, as used by timm ViTs,
DINO/DINOv2, many DETR-style models and Depth Anything 3 — which hit the same
rank-5 wall through a different `view → permute → slice` chain that this matcher
doesn't fold yet. Extending it to that chain (keeping the whole ViT family
GPU-clean) is a natural, high-value follow-up — happy to fold it into this PR or do
a follow-up, whichever you prefer.
