### PR TITLE
Add gemma4 case to build_llm_metadata model type dispatch

### DIFF
--- a/litert_torch/generative/export_hf/core/litert_lm_builder.py
+++ b/litert_torch/generative/export_hf/core/litert_lm_builder.py
@@ -271,6 +271,10 @@ def build_llm_metadata(
       llm_metadata.llm_model_type.CopyFrom(
           llm_model_type_pb2.LlmModelType(gemma3=llm_model_type_pb2.Gemma3())
       )
+    case 'gemma4':
+      llm_metadata.llm_model_type.CopyFrom(
+          llm_model_type_pb2.LlmModelType(gemma4=llm_model_type_pb2.Gemma4())
+      )
     case 'function_gemma':
       llm_metadata.llm_model_type.CopyFrom(
           llm_model_type_pb2.LlmModelType(


### PR DESCRIPTION
build_llm_metadata dispatches on model type to set llm_model_type, but there was no case for gemma4, so metadata built for a gemma4 model fell through the match to generic_model without setting the correct type even though the Gemma4 proto message already exists. Add the missing `case 'gemma4':` mirroring the existing gemma3 and function_gemma cases.

Fixes https://github.com/google-ai-edge/ai-edge-torch/issues/1005
