### PR TITLE
Add experimental tfl-optimize pattern-filtering controls to convert()

### DIFF
--- a/litert_torch/_convert/core.py
+++ b/litert_torch/_convert/core.py
@@ -84,6 +84,9 @@ def convert_signatures(
     lightweight_conversion: bool = False,
     enable_x64: bool = True,
     runtime_constant_folding: bool | None = None,
+    experimental_skip_optimize_pass: bool = False,
+    experimental_optimize_disabled_patterns: list[str] | None = None,
+    experimental_optimize_enabled_patterns: list[str] | None = None,
 ) -> model.LiteRTModel:
   """Converts a list of `signature.Signature`s and embeds them into one `model.LiteRTModel`.
 
@@ -107,6 +110,16 @@ def convert_signatures(
         constants beyond what the standard converter can resolve. If None
         (default), this is enabled automatically when `lightweight_conversion`
         is True to maintain model quality.
+      experimental_skip_optimize_pass: (Experimental) If True, the TFL
+        `tfl-optimize` pass is not run during conversion. Selected
+        optimizations can be applied afterwards with
+        `litert_converter.run_selective_tfl_optimize`.
+      experimental_optimize_disabled_patterns: (Experimental) Substring filters
+        over rewrite-pattern debug names inside `tfl-optimize`; matching
+        patterns are skipped.
+      experimental_optimize_enabled_patterns: (Experimental) If non-empty, only
+        rewrite patterns inside `tfl-optimize` whose debug name contains one of
+        these substrings are run (allowlist mode).
 
   Returns:
     The converted `model.LiteRTModel` object.
@@ -162,6 +175,13 @@ def convert_signatures(
       quant_config=quant_config,
       lightweight_conversion=lightweight_conversion,
       runtime_constant_folding=runtime_constant_folding,
+      experimental_skip_optimize_pass=experimental_skip_optimize_pass,
+      experimental_optimize_disabled_patterns=(
+          experimental_optimize_disabled_patterns
+      ),
+      experimental_optimize_enabled_patterns=(
+          experimental_optimize_enabled_patterns
+      ),
   )
 
   return model.LiteRTModel(exporter)

--- a/litert_torch/_convert/interface.py
+++ b/litert_torch/_convert/interface.py
@@ -140,6 +140,9 @@ class Converter:
       lightweight_conversion: bool = False,
       enable_x64: bool = True,
       runtime_constant_folding: bool | None = None,
+      experimental_skip_optimize_pass: bool = False,
+      experimental_optimize_disabled_patterns: list[str] | None = None,
+      experimental_optimize_enabled_patterns: list[str] | None = None,
   ) -> model.LiteRTModel | litert_types.CompilationResult:
     """Finalizes the conversion and produces an edge model.
 
@@ -179,6 +182,16 @@ class Converter:
         constants beyond what the standard converter can resolve. If None
         (default), this is enabled automatically when `lightweight_conversion`
         is True to maintain model quality.
+      experimental_skip_optimize_pass: (Experimental) If True, skip the TFL
+        `tfl-optimize` pass entirely during conversion. Selected optimizations
+        can be applied afterwards with
+        `litert_torch._convert.litert_converter.run_selective_tfl_optimize`.
+      experimental_optimize_disabled_patterns: (Experimental) Substring filters
+        over rewrite-pattern debug names inside `tfl-optimize`; matching
+        patterns are skipped.
+      experimental_optimize_enabled_patterns: (Experimental) If non-empty, only
+        rewrite patterns inside `tfl-optimize` whose debug name contains one of
+        these substrings are run (allowlist mode).
 
     Returns:
       The converted edge model. If compilation configs are provided, returns the
@@ -212,6 +225,13 @@ class Converter:
         lightweight_conversion=lightweight_conversion,
         enable_x64=enable_x64,
         runtime_constant_folding=runtime_constant_folding,
+        experimental_skip_optimize_pass=experimental_skip_optimize_pass,
+        experimental_optimize_disabled_patterns=(
+            experimental_optimize_disabled_patterns
+        ),
+        experimental_optimize_enabled_patterns=(
+            experimental_optimize_enabled_patterns
+        ),
     )
     if self._compilation_configs:
       return core.aot_compile(self._compilation_configs, converted_model)
@@ -282,6 +302,9 @@ def convert(
     lightweight_conversion: bool = False,
     enable_x64: bool = True,
     runtime_constant_folding: bool | None = None,
+    experimental_skip_optimize_pass: bool = False,
+    experimental_optimize_disabled_patterns: list[str] | None = None,
+    experimental_optimize_enabled_patterns: list[str] | None = None,
 ) -> model.LiteRTModel:
   """Converts a PyTorch model to an edge model with a default signature.
 
@@ -312,6 +335,17 @@ def convert(
       beyond what the standard converter can resolve. If None (default), this is
       enabled automatically when `lightweight_conversion` is True to maintain
       model quality.
+    experimental_skip_optimize_pass: (Experimental) If True, skip the TFL
+      `tfl-optimize` pass entirely during conversion. Selected optimizations
+      can be applied afterwards with
+      `litert_torch._convert.litert_converter.run_selective_tfl_optimize`.
+    experimental_optimize_disabled_patterns: (Experimental) Substring filters
+      over rewrite-pattern debug names inside `tfl-optimize`; matching patterns
+      are skipped. Discover pattern names via the pass's `list-patterns`
+      option or `run_selective_tfl_optimize(..., list_patterns=True)`.
+    experimental_optimize_enabled_patterns: (Experimental) If non-empty, only
+      rewrite patterns inside `tfl-optimize` whose debug name contains one of
+      these substrings are run (allowlist mode).
 
   Returns:
     The converted edge model.
@@ -330,4 +364,11 @@ def convert(
       lightweight_conversion=lightweight_conversion,
       enable_x64=enable_x64,
       runtime_constant_folding=runtime_constant_folding,
+      experimental_skip_optimize_pass=experimental_skip_optimize_pass,
+      experimental_optimize_disabled_patterns=(
+          experimental_optimize_disabled_patterns
+      ),
+      experimental_optimize_enabled_patterns=(
+          experimental_optimize_enabled_patterns
+      ),
   )

--- a/litert_torch/_convert/litert_converter.py
+++ b/litert_torch/_convert/litert_converter.py
@@ -109,6 +109,9 @@ def exported_programs_to_flatbuffer(
     lightweight_conversion: bool = False,
     enable_x64: bool = True,
     runtime_constant_folding: bool | None = None,
+    experimental_skip_optimize_pass: bool = False,
+    experimental_optimize_disabled_patterns: list[str] | None = None,
+    experimental_optimize_enabled_patterns: list[str] | None = None,
 ) -> LazyModelExporter:
   """Convert ExportedPrograms to a LiteRT model."""
   if not exported_programs:
@@ -180,6 +183,20 @@ def exported_programs_to_flatbuffer(
   # litert-torch handles inf clamping before the MLIR conversion.
   config.canonicalizing_inf_as_min_max_float = False
   safe_set_config("enable_x64", enable_x64)
+  # Experimental knobs for the tfl-optimize pass: skip it entirely, or filter
+  # individual rewrite patterns inside it by debug-name substring. Ignored
+  # (with hasattr guard) on litert-converter versions without support.
+  safe_set_config("skip_optimize_pass", experimental_skip_optimize_pass)
+  if experimental_optimize_disabled_patterns is not None:
+    safe_set_config(
+        "optimize_disabled_patterns",
+        list(experimental_optimize_disabled_patterns),
+    )
+  if experimental_optimize_enabled_patterns is not None:
+    safe_set_config(
+        "optimize_enabled_patterns",
+        list(experimental_optimize_enabled_patterns),
+    )
 
   # Run LiteRT converter passes.
   with ir_context, progress.task("Run LiteRT Converter Passes"):
@@ -212,3 +229,70 @@ def exported_programs_to_flatbuffer(
       exporter = LazyModelExporter(content=model_bytes)
 
   return exporter
+
+
+def run_selective_tfl_optimize(
+    model: model_lib.LiteRTModel,
+    *,
+    enabled_patterns: list[str] | None = None,
+    disabled_patterns: list[str] | None = None,
+    list_patterns: bool = False,
+) -> None:
+  """Runs the `tfl-optimize` pass standalone on a not-yet-serialized model.
+
+  This is meant to be combined with
+  `convert(..., experimental_skip_optimize_pass=True)`: convert without the
+  optimize pass, then apply only the optimizations you want. The model's MLIR
+  module is mutated in place; a subsequent `model.export(...)` or
+  `model.model_content()` serializes the optimized module.
+
+  Patterns are matched by substring against their MLIR debug names (the C++
+  class name of the pattern, or the TableGen def name for generated patterns).
+  Use `list_patterns=True` to print every pattern name and its filter verdict
+  to stderr.
+
+  Args:
+    model: A `LiteRTModel` fresh out of conversion (not yet serialized to
+      bytes/file, and not loaded from a file).
+    enabled_patterns: If non-empty, run ONLY patterns whose debug name contains
+      one of these substrings.
+    disabled_patterns: Skip patterns whose debug name contains any of these
+      substrings.
+    list_patterns: Print all pattern debug names with keep/skip verdicts.
+
+  Raises:
+    ValueError: If the model has already been serialized (its MLIR module is
+      gone), or the installed litert-converter does not support tfl-optimize
+      pass options.
+  """
+  exporter = model._exporter  # pylint: disable=protected-access
+  if not isinstance(exporter, LazyModelExporter) or exporter.module is None:
+    raise ValueError(
+        "run_selective_tfl_optimize requires a freshly converted model whose"
+        " MLIR module has not been serialized yet. Run it right after"
+        " convert(), before export()/model_content()/inference, and note that"
+        " quantized conversions serialize eagerly."
+    )
+
+  options = []
+  if enabled_patterns:
+    options.append("enabled-patterns=" + ",".join(enabled_patterns))
+  if disabled_patterns:
+    options.append("disabled-patterns=" + ",".join(disabled_patterns))
+  if list_patterns:
+    options.append("list-patterns=true")
+  options_text = "{" + " ".join(options) + "}" if options else ""
+  pipeline = f"builtin.module(func.func(tfl-optimize{options_text}))"
+
+  module = exporter.module
+  module_op = module.operation if isinstance(module, ir.Module) else module
+  with module_op.context, progress.task("Selective TFL Optimize"):
+    try:
+      pass_manager = passmanager.PassManager.parse(pipeline)
+    except ValueError as e:
+      raise ValueError(
+          "The installed litert-converter does not support tfl-optimize"
+          " pattern filtering options (requires a build with"
+          " enabled-patterns/disabled-patterns support)."
+      ) from e
+    pass_manager.run(module_op)


### PR DESCRIPTION
# Experimental tfl-optimize pattern-filtering controls in `convert()`

## Summary

Companion to **google-ai-edge/LiteRT#8689**, which teaches the converter's `tfl-optimize` pass to skip or exclusively allow individual rewrite patterns by name, and to be omitted from the pipeline entirely. This PR exposes those controls through the litert-torch conversion API:

```python
edge_model = litert_torch.convert(
    model, sample_inputs,
    # skip specific fusions inside tfl-optimize (substring match on
    # rewrite-pattern debug names):
    experimental_optimize_disabled_patterns=["FuseAddAndFullyConnected"],
)
```

```python
# Convert with NO tfl-optimize at all, then selectively apply only the
# optimizations you want:
from litert_torch._convert import litert_converter

edge_model = litert_torch.convert(
    model, sample_inputs, experimental_skip_optimize_pass=True)

litert_converter.run_selective_tfl_optimize(
    edge_model,
    enabled_patterns=["RemoveReshape", "FuseFullyConnectedAndAdd"],
    list_patterns=True,  # prints every pattern name + keep/skip verdict
)
edge_model.export("model.tflite")
```

## What's new

* `convert()`, `Converter.convert()` and `core.convert_signatures()` accept three keyword-only experimental args:
  * `experimental_skip_optimize_pass: bool` — omit `tfl-optimize` from the conversion pipeline (all instances, including post-quantization).
  * `experimental_optimize_disabled_patterns: list[str] | None` — blocklist; matching patterns are skipped.
  * `experimental_optimize_enabled_patterns: list[str] | None` — allowlist; if non-empty, ONLY matching patterns run.
* `litert_converter.run_selective_tfl_optimize(model, *, enabled_patterns, disabled_patterns, list_patterns)` — runs `tfl-optimize` standalone (via a textual `builtin.module(func.func(tfl-optimize{...}))` pipeline) on a freshly converted model whose MLIR module has not been serialized yet. The module is mutated in place; a subsequent `export()` / `model_content()` serializes the selectively optimized model. Raises a clear `ValueError` when the model was already serialized/loaded, or when the installed `litert-converter` predates pattern-filter support.

## Semantics

* Matching is case-sensitive **substring** matching against MLIR rewrite-pattern debug names (the C++ class name of the pattern, or the TableGen def name for generated patterns). `FuseFullyConnectedAndReluX` addresses all template instantiations of that family; longer substrings can target a single instantiation.
* Allowlist + blocklist compose: `kept = (no allowlist OR matches allowlist) AND NOT matches blocklist`.
* Pattern names are discoverable via `list_patterns=True` (stderr lines of the form `[tfl-optimize] phase 1 keep: ...FuseFullyConnectedAndAdd`).
* Filter entries that match nothing are silently ignored — use `list_patterns` to verify a filter actually hits.
* The greedy rewrite driver's built-in constant folding and dead-op erasure are not patterns and always run; in allowlist mode canonicalization patterns are filtered like any other pattern.

## Compatibility

* All flags are forwarded through the existing hasattr-guarded `safe_set_config(...)` mechanism, so running against an older `litert-converter` wheel silently ignores them (identical behavior to today). `run_selective_tfl_optimize` fails loudly instead, since silently skipping the user's explicit request would be misleading.
* Defaults preserve current behavior exactly (`skip=False`, both filters `None`).

## Dependencies / testing status

* Requires a `litert-converter` build that includes google-ai-edge/LiteRT#8689; published wheels do not have it yet.
* `py_compile` clean; not yet exercised end to end because the companion converter change needs a Linux Bazel build. Suggested test once a wheel is available: convert a tiny `Linear+ReLU` module with `experimental_optimize_disabled_patterns=["FuseFullyConnectedAndRelu"]` and assert the relu survives in the flatbuffer, plus an allowlist and a skip+selective-rerun case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
