### PR TITLE
Lower representable adaptive avg pool to TFLite average pool

### DIFF
--- a/litert_torch/_convert/fx_passes/build_aten_composite_pass.py
+++ b/litert_torch/_convert/fx_passes/build_aten_composite_pass.py
@@ -250,6 +250,58 @@ def _aten_avg_pool2d(_: torch.fx.GraphModule, node: torch.fx.Node):
   node.target = avg_pool2d
 
 
+@_register_composite_builder(torch.ops.aten.adaptive_avg_pool2d.default)
+@_register_composite_builder(torch.ops.aten._adaptive_avg_pool2d.default)
+def _aten_adaptive_avg_pool2d(_: torch.fx.GraphModule, node: torch.fx.Node):
+  """Build an avg-pool composite for exactly representable adaptive pooling."""
+  op = node.target
+  args_mapper = TorchOpArgumentsMapper(op)
+
+  def adaptive_avg_pool2d(*args, **kwargs):
+    nonlocal op, args_mapper
+
+    full_kwargs = args_mapper.get_full_kwargs(args, kwargs)
+    input_tensor = full_kwargs["self"]
+    try:
+      input_size = [int(size) for size in input_tensor.shape[-2:]]
+      output_size = [int(size) for size in full_kwargs["output_size"]]
+    except (RuntimeError, TypeError, ValueError):
+      return op(*args, **kwargs)
+
+    # Adaptive pooling is exactly a fixed VALID average pool only when every
+    # input spatial dimension divides evenly into its requested output size.
+    # Leave all other cases to the existing general adaptive-pool lowering.
+    if (
+        len(input_size) != 2
+        or len(output_size) != 2
+        or any(size <= 0 for size in input_size + output_size)
+        or any(
+            input % output for input, output in zip(input_size, output_size)
+        )
+    ):
+      return op(*args, **kwargs)
+
+    kernel_size = [
+        input // output for input, output in zip(input_size, output_size)
+    ]
+    builder = backend.composite.StableHLOCompositeBuilder(
+        "aten.avg_pool2d.default",
+        attr=_tree_map_to_composite_attr_values({
+            "kernel_size": kernel_size,
+            "stride": kernel_size,
+            "padding": [0, 0],
+            "ceil_mode": False,
+            "count_include_pad": True,
+            "divisor_override": None,
+        }),
+    )
+    full_kwargs["self"] = builder.mark_inputs(input_tensor)
+    output = op(**full_kwargs)
+    return builder.mark_outputs(output)
+
+  node.target = adaptive_avg_pool2d
+
+
 @_register_composite_builder(torch.ops.aten.embedding.default)
 def _aten_embedding(gm: torch.fx.GraphModule, node: torch.fx.Node):
   op = node.target

--- a/litert_torch/_convert/fx_passes/test/test_build_aten_composite_pass.py
+++ b/litert_torch/_convert/fx_passes/test/test_build_aten_composite_pass.py
@@ -136,6 +136,20 @@ class TestBuildAtenCompositePass(googletest.TestCase):
     )
     self.assertEqual(stablehlo.count('stablehlo.custom_call @mark_tensor'), 2)
 
+  def test_adaptive_avg_pool2d_exactly_representable(self):
+    stablehlo = _export_to_stablehlo_with_composite(
+        lambda x: torch.nn.functional.adaptive_avg_pool2d(x, (2, 2)),
+        (torch.rand(1, 3, 4, 6),),
+    )
+    self.assertEqual(stablehlo.count('stablehlo.custom_call @mark_tensor'), 2)
+
+  def test_adaptive_avg_pool2d_non_divisible_is_not_a_composite(self):
+    stablehlo = _export_to_stablehlo_with_composite(
+        lambda x: torch.nn.functional.adaptive_avg_pool2d(x, (2, 2)),
+        (torch.rand(1, 3, 5, 6),),
+    )
+    self.assertEqual(stablehlo.count('stablehlo.custom_call @mark_tensor'), 0)
+
   def test_gelu_layer(self):
     stablehlo = _export_to_stablehlo_with_composite(
         lambda x: torch.nn.GELU()(x), (torch.rand(10, 10),)  # pylint: disable=unnecessary-lambda

--- a/litert_torch/_convert/test/test_convert_composites.py
+++ b/litert_torch/_convert/test/test_convert_composites.py
@@ -17,11 +17,17 @@
 from collections.abc import Callable
 
 import litert_torch
+from litert_torch.quantize import pt2e_quantizer
+from litert_torch.quantize.quant_config import QuantConfig
 from litert_torch.testing import model_coverage
+import numpy as np
 import parameterized
 import torch
+from torch import nn
+from torchao.quantization.pt2e import quantize_pt2e
 
 from absl.testing import absltest as googletest
+from ai_edge_litert import interpreter as tfl_interpreter
 
 
 def _func_to_torch_module(func: Callable[..., torch.Tensor]):
@@ -92,6 +98,44 @@ class TestConvertComposites(googletest.TestCase):
             edge_model, torch_module, tracing_args
         )
     )
+
+  def test_convert_adaptive_avg_pool2d_pt2e_static(self):
+    class ConvAdaptivePoolConv(nn.Module):
+
+      def __init__(self):
+        super().__init__()
+        self.pre = nn.Conv2d(3, 4, 1)
+        self.post = nn.Conv2d(4, 5, 1)
+
+      def forward(self, x):
+        return self.post(torch.nn.functional.adaptive_avg_pool2d(
+            self.pre(x), (1, 1)
+        ))
+
+    args = (torch.randn(1, 3, 4, 4),)
+    quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
+        pt2e_quantizer.get_symmetric_quantization_config(is_per_channel=True)
+    )
+    model = torch.export.export(ConvAdaptivePoolConv().eval(), args).module()
+    model = quantize_pt2e.prepare_pt2e(model, quantizer)
+    for _ in range(4):
+      model(torch.randn_like(args[0]))
+    model = quantize_pt2e.convert_pt2e(model, fold_quantize=False)
+
+    edge_model = litert_torch.convert(
+        model, args, quant_config=QuantConfig(pt2e_quantizer=quantizer)
+    )
+    interpreter = tfl_interpreter.Interpreter(
+        model_content=edge_model.model_content()
+    )
+    interpreter.allocate_tensors()
+    op_names = [op["op_name"] for op in interpreter._get_ops_details()]
+
+    self.assertIn("AVERAGE_POOL_2D", op_names)
+    self.assertNotIn("DEQUANTIZE", op_names)
+    self.assertNotIn("SUM", op_names)
+    self.assertEqual(interpreter.get_input_details()[0]["dtype"], np.int8)
+    self.assertEqual(interpreter.get_output_details()[0]["dtype"], np.int8)
 
   @parameterized.parameterized.expand([
       # use scale_factor with align_corners=False


### PR DESCRIPTION
## Summary
- recognize statically divisible `adaptive_avg_pool2d` shapes as fixed valid average pooling
- route those cases through the existing `aten.avg_pool2d.default` composite and TFLite `AVERAGE_POOL_2D` lowering
- retain the existing general lowering for non-divisible or dynamic cases
- add composite and static-PT2E regression coverage

## Reproduction
Before, static PT2E QDQ `Conv2d -> AdaptiveAvgPool2d((1, 1)) -> Conv2d` emitted `CONV_2D, DEQUANTIZE, SUM, MUL, QUANTIZE, CONV_2D`.

After this change it emits `CONV_2D, AVERAGE_POOL_2D, CONV_2D` with int8 input/output.

## Validation
- `python -m unittest litert_torch._convert.fx_passes.test.test_build_aten_composite_pass -q`
- local static-QDQ conversion probe confirms `AVERAGE_POOL_2D`, int8 I/O, and no `DEQUANTIZE`/`SUM`.