### PR TITLE
Pass valid_mask to cache_update signatures in calibration executor

### DIFF
--- a/litert_torch/generative/export_hf/experimental/calib/sampling_executor.py
+++ b/litert_torch/generative/export_hf/experimental/calib/sampling_executor.py
@@ -522,12 +522,18 @@ class Executor:
         self.prefill_runners[input_size],
     )
 
+    prefill_cache_update_inputs = {
+        **kv_slice,
+        **decode_state.kv_cache,
+        'input_pos': positions,
+    }
+    if (
+        'valid_mask'
+        in self.prefill_cache_update_runners[input_size].get_input_details()
+    ):
+      prefill_cache_update_inputs['valid_mask'] = valid_mask
     new_kv_cache = try_run_signature_with_quant_dequant(
-        {
-            **kv_slice,
-            **decode_state.kv_cache,
-            'input_pos': positions,
-        },
+        prefill_cache_update_inputs,
         self.prefill_cache_update_runners[input_size],
     )
 
@@ -612,12 +618,15 @@ class Executor:
 
     logits = kv_slice.pop('logits')
 
+    decode_cache_update_inputs = {
+        **kv_slice,
+        **decode_state.kv_cache,
+        'input_pos': positions,
+    }
+    if 'valid_mask' in self.decode_cache_update_runner.get_input_details():
+      decode_cache_update_inputs['valid_mask'] = np.ones((1, 1), dtype=np.bool)
     new_kv_cache = try_run_signature_with_quant_dequant(
-        {
-            **kv_slice,
-            **decode_state.kv_cache,
-            'input_pos': positions,
-        },
+        decode_cache_update_inputs,
         self.decode_cache_update_runner,
     )
 


### PR DESCRIPTION
This is the fix proposed in #1177: Stage 2 calibration fails with `KeyError: 'valid_mask'` on any bundle exported from current main, because split-cache exports have emitted `prefill_cache_update_*` / `decode_cache_update` signatures with a `valid_mask` input since bac4c9e, while the sampling executor only fed `valid_mask` to the mask runners.

Both cache-update call sites (`prefill_chunk`, `decode_step`) now pass `valid_mask`, guarded on `get_input_details()` exactly like the existing mask-runner handling — bundles whose cache-update signatures don't have the input keep working unchanged.

**Rebased onto main at `8379afb`, and re-verified as a two-run A/B so the difference is reproducible from a checkout.**

Both runs consume one Stage 1 bundle (Qwen/Qwen3-0.6B, `prefill_lengths=[128]`, `cache_length=1024`, `dynamic_wi8_afp32`) and the same 3-prompt calibration set at 8 decode steps. The only difference is `PYTHONPATH` — a pristine `8379afb` tree, or this branch. Stage 1 is untouched by this PR: the diff changes two methods of the calibration executor, which the export stage never runs, so both runs see the same bundle.

|  | main `8379afb` | this branch |
|---|---|---|
| Stage 2 calibrate | `KeyError: 'valid_mask'` after 2 s, at `sampling_executor.py:525` in `prefill_chunk` | OK in 6 s, 3/3 examples |
| calibration output | 0 files | 4 files |
| Stage 3 quantize | not reached | OK in 7 s, SRQ bundle written (771,346,785 B) |

```
git archive 8379afb | tar -x -C /tmp/main_tree
git archive HEAD    | tar -x -C /tmp/branch_tree
# stage2.py: the npu_calibrate call from #1177, against a bundle exported once
PYTHONPATH=/tmp/main_tree   python stage2.py   # KeyError: 'valid_mask'
PYTHONPATH=/tmp/branch_tree python stage2.py   # calibrate and quantize both complete
```

Environment: macOS arm64, Python 3.12.13, ai-edge-litert-nightly 2.3.0.dev20260819, ai-edge-quantizer-nightly 0.9.0.dev20260820, litert-converter 0.4.0.dev20260819. The full traceback and the signature dump are in #1177.

Happy to reshape this if you'd rather fix it elsewhere (e.g. on the export side).
