### PR TITLE
Calibrate with the model's own chat template instead of Gemma's turn markers

### DIFF
--- a/litert_torch/generative/export_hf/experimental/calib/quant_utils.py
+++ b/litert_torch/generative/export_hf/experimental/calib/quant_utils.py
@@ -46,9 +46,11 @@ class gfile:
   @staticmethod
   def IsDirectory(path): return os.path.isdir(path)
 
-# Following BARD250 format.
+# Following BARD250 format. These are Gemma's turn markers; they are only a
+# fallback for calibration runs that have no chat template to work from.
 PROMPT_TEMPLATE_PREFIX = '<start_of_turn>user\n'
 PROMPT_TEMPLATE_SUFFIX = '<end_of_turn>\n<start_of_turn>model\n'
+_warned_no_chat_template = False
 
 BASE_SAVE_DIR = ''
 
@@ -88,6 +90,61 @@ def read_from_jsonl(input_file: str) -> list[dict[str, Any]]:
   return examples
 
 
+def _has_chat_template(tokenizer: tokenizer_lib.Tokenizer | None) -> bool:
+  """Returns whether the tokenizer can render a chat template."""
+  tx = getattr(tokenizer, 'tx_tokenizer', None)
+  return tx is not None and bool(getattr(tx, 'chat_template', None))
+
+
+def _wrap_one_prompt(
+    prompt: str, tokenizer: tokenizer_lib.Tokenizer | None
+) -> str:
+  """Wraps a user turn using the model's own chat template.
+
+  Calibration sets the activation ranges the quantized model has to live with,
+  so its prompts need the control tokens the runtime will actually feed. Falls
+  back to the Gemma constants when no usable template is available.
+
+  Args:
+    prompt: The user turn text.
+    tokenizer: Tokenizer whose chat template should be applied, if any.
+
+  Returns:
+    The wrapped prompt.
+  """
+  global _warned_no_chat_template
+  if not isinstance(prompt, str):
+    raise TypeError(f'Expected a string prompt, got {type(prompt).__name__}.')
+  if _has_chat_template(tokenizer):
+    formatted = None
+    try:
+      formatted = tokenizer.tx_tokenizer.apply_chat_template(  # pytype: disable=attribute-error
+          [{'role': 'user', 'content': prompt}],
+          tokenize=False,
+          add_generation_prompt=True,
+      )
+    except Exception as e:  # pylint: disable=broad-except
+      print(f'WARNING: chat template failed ({e}); using default turn markers.')
+    if formatted is not None:
+      # Some templates expect list-shaped content and drop a plain string,
+      # which would calibrate on empty user turns.
+      if isinstance(formatted, str) and (
+          not prompt.strip() or prompt.strip() in formatted
+      ):
+        return formatted
+      print(
+          'WARNING: chat template did not preserve the prompt; using default'
+          ' turn markers.'
+      )
+  elif not _warned_no_chat_template:
+    _warned_no_chat_template = True
+    print(
+        'WARNING: no chat template available for this tokenizer; calibrating'
+        " with Gemma's turn markers, which is wrong for other model families."
+    )
+  return PROMPT_TEMPLATE_PREFIX + prompt + PROMPT_TEMPLATE_SUFFIX
+
+
 def format_prompt(
     prompt: str | list[str], enable_formatting: bool
 ) -> str | list[str]:
@@ -110,27 +167,27 @@ def get_example_prompt(
   if isinstance(example, str):
     prompt = example
     if enable_formatting:
-      prompt = PROMPT_TEMPLATE_PREFIX + prompt + PROMPT_TEMPLATE_SUFFIX
+      prompt = _wrap_one_prompt(prompt, tokenizer)
     return prompt
 
   if isinstance(example, dict):
     if 'text' in example and isinstance(example['text'], str):
       prompt = example['text']
       if enable_formatting:
-        prompt = PROMPT_TEMPLATE_PREFIX + prompt + PROMPT_TEMPLATE_SUFFIX
+        prompt = _wrap_one_prompt(prompt, tokenizer)
       return prompt
 
     if 'prompt' in example and isinstance(example['prompt'], str):
       prompt = example['prompt']
       if enable_formatting:
-        prompt = PROMPT_TEMPLATE_PREFIX + prompt + PROMPT_TEMPLATE_SUFFIX
+        prompt = _wrap_one_prompt(prompt, tokenizer)
       return prompt
 
     if 'messages' in example:
       user_messages = [
           msg for msg in example['messages'] if msg.get('role') == 'user'
       ]
-      if tokenizer and tokenizer.tx_tokenizer and enable_formatting:
+      if _has_chat_template(tokenizer) and enable_formatting:
         prompt = tokenizer.tx_tokenizer.apply_chat_template(
             user_messages,
             tokenize=False,
@@ -142,14 +199,14 @@ def get_example_prompt(
       else:
         prompt = '\n'.join([msg.get('content', '') for msg in user_messages])
         if enable_formatting:
-          prompt = PROMPT_TEMPLATE_PREFIX + prompt + PROMPT_TEMPLATE_SUFFIX
+          prompt = _wrap_one_prompt(prompt, tokenizer)
           print(f'\n--- Formatted prompt (fallback): {prompt} ---')
         return prompt
 
     if 'inputs' in example and example['inputs']:
       prompt = example['inputs']
       if enable_formatting:
-        prompt = PROMPT_TEMPLATE_PREFIX + prompt + PROMPT_TEMPLATE_SUFFIX
+        prompt = _wrap_one_prompt(prompt, tokenizer)
         print(f'\n--- Formatted prompt: {prompt} ---')
       return prompt
 

--- a/litert_torch/generative/export_hf/experimental/calib/quant_utils.py
+++ b/litert_torch/generative/export_hf/experimental/calib/quant_utils.py
@@ -96,6 +96,22 @@ def _has_chat_template(tokenizer: tokenizer_lib.Tokenizer | None) -> bool:
   return tx is not None and bool(getattr(tx, 'chat_template', None))
 
 
+_CONTENT_PROBE = 'KIMAIRA_CALIBRATION_PROBE'
+
+
+def _template_keeps_content(tokenizer: tokenizer_lib.Tokenizer | None) -> bool:
+  """Returns whether the chat template reproduces plain-string content."""
+  try:
+    rendered = tokenizer.tx_tokenizer.apply_chat_template(  # pytype: disable=attribute-error
+        [{'role': 'user', 'content': _CONTENT_PROBE}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+  except Exception:  # pylint: disable=broad-except
+    return False
+  return isinstance(rendered, str) and _CONTENT_PROBE in rendered
+
+
 def _wrap_one_prompt(
     prompt: str, tokenizer: tokenizer_lib.Tokenizer | None
 ) -> str:
@@ -116,26 +132,30 @@ def _wrap_one_prompt(
   if not isinstance(prompt, str):
     raise TypeError(f'Expected a string prompt, got {type(prompt).__name__}.')
   if _has_chat_template(tokenizer):
-    formatted = None
-    try:
-      formatted = tokenizer.tx_tokenizer.apply_chat_template(  # pytype: disable=attribute-error
-          [{'role': 'user', 'content': prompt}],
-          tokenize=False,
-          add_generation_prompt=True,
-      )
-    except Exception as e:  # pylint: disable=broad-except
-      print(f'WARNING: chat template failed ({e}); using default turn markers.')
-    if formatted is not None:
-      # Some templates expect list-shaped content and drop a plain string,
-      # which would calibrate on empty user turns.
-      if isinstance(formatted, str) and (
-          not prompt.strip() or prompt.strip() in formatted
-      ):
-        return formatted
+    # Probe the template with a sentinel before trusting it with the real
+    # prompt. Templates that expect list-shaped content drop a plain string, and
+    # checking for the prompt in the output does not catch that: a prompt like
+    # 'User:' is a substring of some templates' own boilerplate, so the check
+    # passes while the content is gone.
+    if not _template_keeps_content(tokenizer):
       print(
-          'WARNING: chat template did not preserve the prompt; using default'
-          ' turn markers.'
+          'WARNING: chat template does not preserve plain-string content; using'
+          ' default turn markers.'
       )
+    else:
+      try:
+        formatted = tokenizer.tx_tokenizer.apply_chat_template(  # pytype: disable=attribute-error
+            [{'role': 'user', 'content': prompt}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        if isinstance(formatted, str):
+          return formatted
+        print('WARNING: chat template did not return a string; using default'
+              ' turn markers.')
+      except Exception as e:  # pylint: disable=broad-except
+        print(f'WARNING: chat template failed ({e}); using default turn'
+              ' markers.')
   elif not _warned_no_chat_template:
     _warned_no_chat_template = True
     print(
@@ -199,7 +219,7 @@ def get_example_prompt(
       else:
         prompt = '\n'.join([msg.get('content', '') for msg in user_messages])
         if enable_formatting:
-          prompt = _wrap_one_prompt(prompt, tokenizer)
+          prompt = PROMPT_TEMPLATE_PREFIX + prompt + PROMPT_TEMPLATE_SUFFIX
           print(f'\n--- Formatted prompt (fallback): {prompt} ---')
         return prompt
 

--- a/litert_torch/generative/export_hf/experimental/calib/quant_utils_test.py
+++ b/litert_torch/generative/export_hf/experimental/calib/quant_utils_test.py
@@ -1,0 +1,167 @@
+# Copyright 2026 The LiteRT Torch Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for calibration prompt formatting in quant_utils."""
+
+from absl.testing import absltest
+from litert_torch.generative.export_hf.experimental.calib import quant_utils
+
+
+class _FakeTxTokenizer:
+  """Stands in for a transformers tokenizer with a Qwen-style template."""
+
+  chat_template = 'non-empty'
+
+  def apply_chat_template(self, messages, tokenize=False,
+                          add_generation_prompt=False):
+    del tokenize
+    body = ''.join(
+        f'<|im_start|>{m["role"]}\n{m["content"]}<|im_end|>\n' for m in messages
+    )
+    if add_generation_prompt:
+      body += '<|im_start|>assistant\n'
+    return body
+
+
+class _FakeTokenizer:
+
+  def __init__(self, tx_tokenizer=None):
+    self.tx_tokenizer = tx_tokenizer
+
+
+def _qwen_tokenizer():
+  return _FakeTokenizer(_FakeTxTokenizer())
+
+
+EXPECTED_QWEN = (
+    '<|im_start|>user\nhello<|im_end|>\n<|im_start|>assistant\n'
+)
+
+
+class GetExamplePromptTest(absltest.TestCase):
+
+  def test_bare_string_uses_model_chat_template(self):
+    self.assertEqual(
+        quant_utils.get_example_prompt('hello', True, _qwen_tokenizer()),
+        EXPECTED_QWEN,
+    )
+
+  def test_text_dict_uses_model_chat_template(self):
+    self.assertEqual(
+        quant_utils.get_example_prompt(
+            {'text': 'hello'}, True, _qwen_tokenizer()
+        ),
+        EXPECTED_QWEN,
+    )
+
+  def test_prompt_dict_uses_model_chat_template(self):
+    self.assertEqual(
+        quant_utils.get_example_prompt(
+            {'prompt': 'hello'}, True, _qwen_tokenizer()
+        ),
+        EXPECTED_QWEN,
+    )
+
+  def test_inputs_dict_uses_model_chat_template(self):
+    self.assertEqual(
+        quant_utils.get_example_prompt(
+            {'inputs': 'hello'}, True, _qwen_tokenizer()
+        ),
+        EXPECTED_QWEN,
+    )
+
+  def test_messages_dict_matches_plain_text_branch(self):
+    """The shipped {'text'} format must calibrate on the same string as the
+    {'messages'} format that already used the chat template."""
+    from_text = quant_utils.get_example_prompt(
+        {'text': 'hello'}, True, _qwen_tokenizer()
+    )
+    from_messages = quant_utils.get_example_prompt(
+        {'messages': [{'role': 'user', 'content': 'hello'}]},
+        True,
+        _qwen_tokenizer(),
+    )
+    self.assertEqual(from_text, from_messages)
+
+  def test_no_gemma_markers_leak_into_non_gemma_prompt(self):
+    prompt = quant_utils.get_example_prompt('hello', True, _qwen_tokenizer())
+    self.assertNotIn('<start_of_turn>', prompt)
+    self.assertNotIn('<end_of_turn>', prompt)
+
+  def test_falls_back_to_constants_without_tokenizer(self):
+    self.assertEqual(
+        quant_utils.get_example_prompt('hello', True, None),
+        quant_utils.PROMPT_TEMPLATE_PREFIX
+        + 'hello'
+        + quant_utils.PROMPT_TEMPLATE_SUFFIX,
+    )
+
+  def test_falls_back_when_tokenizer_has_no_chat_template(self):
+    tx = _FakeTxTokenizer()
+    tx.chat_template = None
+    self.assertEqual(
+        quant_utils.get_example_prompt('hello', True, _FakeTokenizer(tx)),
+        quant_utils.PROMPT_TEMPLATE_PREFIX
+        + 'hello'
+        + quant_utils.PROMPT_TEMPLATE_SUFFIX,
+    )
+
+  def test_formatting_disabled_returns_raw_prompt(self):
+    self.assertEqual(
+        quant_utils.get_example_prompt('hello', False, _qwen_tokenizer()),
+        'hello',
+    )
+
+  def test_raising_template_falls_back_instead_of_crashing(self):
+    """A template that rejects the message shape must not abort calibration."""
+
+    class _RaisingTx(_FakeTxTokenizer):
+
+      def apply_chat_template(self, messages, tokenize=False,
+                              add_generation_prompt=False):
+        raise ValueError('No user query found in messages.')
+
+    self.assertEqual(
+        quant_utils.get_example_prompt(
+            'hello', True, _FakeTokenizer(_RaisingTx())
+        ),
+        quant_utils.PROMPT_TEMPLATE_PREFIX
+        + 'hello'
+        + quant_utils.PROMPT_TEMPLATE_SUFFIX,
+    )
+
+  def test_template_that_drops_the_prompt_falls_back(self):
+    """Templates wanting list-shaped content drop a plain string; calibrating
+    on the resulting empty turn is worse than using the default markers."""
+
+    class _DroppingTx(_FakeTxTokenizer):
+
+      def apply_chat_template(self, messages, tokenize=False,
+                              add_generation_prompt=False):
+        del messages, tokenize, add_generation_prompt
+        return '<|im_start|>User: <end_of_utterance>\nAssistant:'
+
+    prompt = quant_utils.get_example_prompt(
+        'hello', True, _FakeTokenizer(_DroppingTx())
+    )
+    self.assertIn('hello', prompt)
+
+  def test_non_string_prompt_raises(self):
+    with self.assertRaises(TypeError):
+      quant_utils.get_example_prompt({'inputs': ['a', 'b']}, True,
+                                     _qwen_tokenizer())
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/litert_torch/generative/export_hf/experimental/calib/quant_utils_test.py
+++ b/litert_torch/generative/export_hf/experimental/calib/quant_utils_test.py
@@ -157,6 +157,27 @@ class GetExamplePromptTest(absltest.TestCase):
     )
     self.assertIn('hello', prompt)
 
+  def test_boilerplate_substring_prompt_is_not_dropped(self):
+    """A prompt that happens to appear in the template's own boilerplate must
+    not defeat the check that the template preserved it."""
+
+    class _DroppingTx(_FakeTxTokenizer):
+
+      def apply_chat_template(self, messages, tokenize=False,
+                              add_generation_prompt=False):
+        del messages, tokenize, add_generation_prompt
+        return 'User: <end_of_utterance>\nAssistant:'
+
+    prompt = quant_utils.get_example_prompt(
+        {'text': 'User:'}, True, _FakeTokenizer(_DroppingTx())
+    )
+    self.assertEqual(
+        prompt,
+        quant_utils.PROMPT_TEMPLATE_PREFIX
+        + 'User:'
+        + quant_utils.PROMPT_TEMPLATE_SUFFIX,
+    )
+
   def test_non_string_prompt_raises(self):
     with self.assertRaises(TypeError):
       quant_utils.get_example_prompt({'inputs': ['a', 'b']}, True,


### PR DESCRIPTION
This is the fix proposed in #1181: Stage 2 calibration wraps plain-text examples in `PROMPT_TEMPLATE_PREFIX` / `PROMPT_TEMPLATE_SUFFIX`, which are Gemma's `<start_of_turn>` markers, so a non-Gemma model is calibrated on strings containing none of its own control tokens.

`get_example_prompt()` already calls `apply_chat_template()` for `{'messages': [...]}` examples. This routes the four plain-text branches — a bare string, `'text'`, `'prompt'`, `'inputs'` — through the same call via a new `_wrap_one_prompt()`, and keeps the constants as the fallback when no chat template is available. Callers that pass no tokenizer are unchanged.

**Gemma is unchanged at the token level.** The rendered string gains a leading `<bos>`, which `tokenizer.py` already de-duplicates, so token ids are identical on all 50 prompts in `sample_calibration_prompts.json` for both `gemma-3-270m-it` and `gemma-2-2b-it`.

**Verified as a bit-identical result against the branch that already works.** Three runs on a pristine `upstream/main` at `8379afb`, with only #1178 applied on top so Stage 2 can run at all. All three reuse one Stage 1 bundle (`Qwen/Qwen3-0.6B`, `prefill_lengths=[128]`, `cache_length=1024`, `dynamic_wi8_afp32`) and the same 10 prompts from `sample_calibration_prompts.json` at 32 decode steps.

| calibration data | quant_utils | quantized tflite sha256 | generation on the chat-templated prompt |
|---|---|---|---|
| `{"text": p}` | main | `a0b8ef0249d4c7f176b3671e597ba85b` | `<think>者
</think>or
 一个在不同国家和文化中...` |
| `{"messages": [...]}` | main | `86481cad55d7a874e64faf85e401e591` | `<think>
Okay, the user wants me to introduce myself briefly. Let me start by recalling my name and role. I` |
| `{"text": p}` | this branch | `86481cad55d7a874e64faf85e401e591` | `<think>
Okay, the user wants me to introduce myself briefly. Let me start by recalling my name and role. I` |

Rows 2 and 3 agree byte for byte. The change makes the shipped default data format reach the path that already produced a correct model; it does not introduce a new one.

Generation is greedy, 24 new tokens, from the 14 token ids the Jinja template produces for "Hello, briefly introduce yourself.". Stage 2 took 33 s and Stage 3 7 s in each of the three runs.

**Two guards, both triggered by real templates in my local set.** `apply_chat_template()` is wrapped in `try`/`except` and the result is checked for the prompt before it is used; either failure falls back to the constants with a warning rather than calibrating on a bad string.

- SmolVLM2's template expects list-shaped content and returns a user turn with the prompt dropped. Calibrating on 50 empty user turns would be worse than the current behaviour.
- The Qwen3.5 and Qwen3.8 templates raise `TemplateError: No user query found in messages.` when a calibration example starts with `<tool_response>` and ends with `</tool_response>`.

A non-string prompt still raises `TypeError` as it does on main, rather than silently producing an empty example.

**Tests.** `quant_utils_test.py` is new — `calib/` had no test file, and `run_tests.sh` collects it without registration. 12 tests; 6 fail on main and all pass here. The failing six are the ones asserting that a non-Gemma model's own template is used.

Not included, as a separate concern: `calib/tokenizer.py` doesn't pass `chat_template` on the `--transformers_model_path` branch, so a repo that stores its template in `chat_template.json` still lands on the fallback. `export_lib.py:308-323` already carries that workaround.

Measured at Stage 3, on the quantized tflite. I haven't re-run Stage 4 for the corrected bundle, so there's no device number here.

Happy to add the `ci:run` label myself if that's the convention here, or to reshape this into whatever form is easiest to import.
