### PR TITLE
Add optional per-signature decode cache sizes for split-context export

### DIFF
--- a/litert_torch/generative/export_hf/core/export_lib.py
+++ b/litert_torch/generative/export_hf/core/export_lib.py
@@ -373,6 +373,28 @@ def get_prefill_decode_exportable_cls(
     )
 
 
+def _decode_export_config(
+    export_config: exportable_module.ExportableModuleConfig,
+) -> exportable_module.ExportableModuleConfig:
+  """Returns the export config to use for the decode signature.
+
+  Substitutes `decode_cache_length` and `decode_sliding_window_ring_buffer_size`
+  for their prefill counterparts; see `ExportableModuleConfig` for what each
+  means. Returns `export_config` itself when neither is set, so callers can
+  `is`-check to skip rebuilding decode-only modules.
+  """
+  replacements = {}
+  if export_config.decode_cache_length is not None:
+    replacements['cache_length'] = export_config.decode_cache_length
+  if export_config.decode_sliding_window_ring_buffer_size is not None:
+    replacements['sliding_window_ring_buffer_size'] = (
+        export_config.decode_sliding_window_ring_buffer_size
+    )
+  if not replacements:
+    return export_config
+  return dataclasses.replace(export_config, **replacements)
+
+
 @progress.task('Export text prefill-decode model')
 def export_text_prefill_decode_model(
     source_model_artifacts: SourceModelArtifacts,
@@ -414,7 +436,7 @@ def export_text_prefill_decode_model(
         model, export_config, source_model_artifacts
     )
     decode_module = decode_module_cls(
-        model, export_config, source_model_artifacts
+        model, _decode_export_config(export_config), source_model_artifacts
     )
     converter = converter_utils.Converter()
     sample_prefill_inputs = prefill_module.get_sample_inputs(text_model_config)
@@ -833,24 +855,49 @@ def export_auxiliary_model(
     )
   # Attention Mask
   sliding_window_sizes = [getattr(text_model_config, 'sliding_window', None)]
-  attention_mask_module = split_cache_module.SplitAttentionMaskBuilder(
+  # Mask widths are baked into the builder at construction, so a decode-only
+  # size needs its own builder for the `decode_mask` signature.
+  decode_config = _decode_export_config(export_config)
+  prefill_mask_module = split_cache_module.SplitAttentionMaskBuilder(
       export_config,
       sliding_window_sizes=sliding_window_sizes,
   )
-  sample_inputs = attention_mask_module.get_sample_inputs(
+  decode_mask_module = (
+      prefill_mask_module
+      if decode_config is export_config
+      else split_cache_module.SplitAttentionMaskBuilder(
+          decode_config,
+          sliding_window_sizes=sliding_window_sizes,
+      )
+  )
+  sample_inputs = prefill_mask_module.get_sample_inputs(
       text_model_config, export_config
   )
   for signature_name, (sample_input, _) in sample_inputs.items():
+    mask_module = (
+        decode_mask_module
+        if signature_name == 'decode_mask'
+        else prefill_mask_module
+    )
     converter.add_signature(
         signature_name,
-        attention_mask_module.eval(),
+        mask_module.eval(),
         sample_kwargs=sample_input,
     )
   # Cache Update
+  # CacheUpdate is stateless; its sizes come from the sample inputs, so the
+  # decode sample must be re-derived to match the decode signature.
   cache_update_module = split_cache_module.CacheUpdate()
   sample_inputs = cache_update_module.get_sample_inputs(
       text_model_config, export_config
   )
+  if decode_config is not export_config:
+    decode_cache_update_inputs = cache_update_module.get_sample_inputs(
+        text_model_config, decode_config
+    )
+    sample_inputs['decode_cache_update'] = decode_cache_update_inputs[
+        'decode_cache_update'
+    ]
   for signature_name, (sample_input, _) in sample_inputs.items():
     converter.add_signature(
         signature_name,

--- a/litert_torch/generative/export_hf/core/exportable_module_config.py
+++ b/litert_torch/generative/export_hf/core/exportable_module_config.py
@@ -43,6 +43,29 @@ class ExportableModuleConfig:
   prefill_lengths: list[int] = dataclasses.field(default_factory=lambda: [128])
   cache_length: int = 4096
   sliding_window_ring_buffer_size: int | None = None
+  # Optional distinct KV-cache length for the decode signature. When None,
+  # decode reuses `cache_length` (default, single shared size). When set, the
+  # prefill signature keeps `cache_length` while decode is exported against
+  # `decode_cache_length`. This lets both signatures target the same total
+  # context on the full_attention (global) layers (e.g. context=16384: prefill
+  # cache=16256 + chunk 128, decode cache=16383 + 1). Sliding_attention layers
+  # are unaffected -- they use the fixed `sliding_window_ring_buffer_size` ring
+  # for both signatures. NOTE: the LiteRT-LM runtime currently shares a single
+  # physical KV buffer across signatures, so a model with differing global
+  # lengths is export-only (not runnable) without matching runtime changes.
+  decode_cache_length: int | None = None
+  # Optional distinct ring-buffer (local past) size for the DECODE signature of
+  # sliding_attention layers. When None, decode reuses
+  # `sliding_window_ring_buffer_size` (shared size, unchanged default). When set,
+  # the prefill signature keeps `sliding_window_ring_buffer_size` while decode is
+  # exported against this size, letting both signatures reach the same sliding
+  # window: e.g. window=1024 as prefill 896 + chunk 128 and decode 1023 + 1. The
+  # window bound W (= model `sliding_window`) is unchanged for both signatures;
+  # only the physical ring size S differs. This is the ring-buffer equivalent of
+  # the global split-context `decode_cache_length`, and carries the same
+  # export-only caveat (the runtime shares one physical local KV buffer across
+  # signatures).
+  decode_sliding_window_ring_buffer_size: int | None = None
   # For quantization
   quantization_recipe: str | None = "dynamic_wi8_afp32"
   # For dynamic shape

--- a/litert_torch/generative/export_hf/export.py
+++ b/litert_torch/generative/export_hf/export.py
@@ -87,6 +87,7 @@ def export(
     trust_remote_code: bool = False,
     prefill_lengths: list[int] | None = None,
     cache_length: int | None = None,
+    decode_cache_length: int | None = None,
     quantization_recipe: str | None = None,
     enable_dynamic_shape: bool | None = None,
     enable_gpu_dynamic_prefill: bool | None = None,
@@ -120,6 +121,7 @@ def export(
     experimental_lightweight_conversion: bool = False,
     experimental_transpile_chat_template_for_minijinja: bool = False,
     sliding_window_ring_buffer_size: int | None = None,
+    decode_sliding_window_ring_buffer_size: int | None = None,
     use_litert_lm_compiler: bool = False,
     compile_configs: str | None = None,
     calibration_dataset_dir: str | None = None,
@@ -148,6 +150,13 @@ def export(
     trust_remote_code: Whether to trust remote code.
     prefill_lengths: The lengths of the prefill input, separated by comma.
     cache_length: The length of the cache.
+    decode_cache_length: Optional distinct KV-cache length for the decode
+      signature's full_attention (global) layers. When unset, decode reuses
+      cache_length. When set, prefill uses cache_length and decode uses this
+      value so both reach the same total context (e.g. context=16384: prefill
+      16256 + chunk 128, decode 16383 + 1). Sliding layers are unaffected (they
+      use sliding_window_ring_buffer_size for both). Export-only unless the
+      runtime is changed to allow per-signature KV-cache sizes.
     quantization_recipe: The quantization recipes to use, separated by comma.
     enable_dynamic_shape: Whether to enable dynamic shape.
     enable_gpu_dynamic_prefill: Whether to enable GPU dynamic shapes (magic
@@ -183,7 +192,16 @@ def export(
     experimental_lightweight_conversion: Whether to use lightweight conversion,
       which might speed up large model conversion, but might not work for all
       models.
-    sliding_window_ring_buffer_size: The size of the sliding window ring buffer.
+    sliding_window_ring_buffer_size: The size of the sliding window ring buffer
+      (the local past cache) used for both signatures by default.
+    decode_sliding_window_ring_buffer_size: Optional distinct ring-buffer (local
+      past) size for the decode signature's sliding_attention layers. When unset,
+      decode reuses sliding_window_ring_buffer_size. When set, prefill uses
+      sliding_window_ring_buffer_size and decode uses this value so both reach the
+      same sliding window (e.g. window=1024: prefill 896 + chunk 128, decode
+      1023 + 1). The window bound (= model sliding_window) is unchanged for both.
+      Ring-buffer equivalent of decode_cache_length; export-only unless the
+      runtime is changed to allow per-signature local cache sizes.
     sampler_top_p: The top_p sampling parameter.
     sampler_temperature: The temperature sampling parameter.
     sampler_top_k: The top_k sampling parameter.


### PR DESCRIPTION
Prefill and decode shared one size for each cache, so decode reached only one token past the prefill size rather than the full context. Give decode its own size for both cache kinds:

  decode_cache_length                     full_attention (global) layers
  decode_sliding_window_ring_buffer_size  sliding_attention (local) layers

Prefill keeps cache_length and sliding_window_ring_buffer_size; decode uses the new values, so both signatures reach the same context (16384 as prefill 16256 + chunk 128, decode 16383 + 1) and the same sliding window (1024 as prefill 896 + 128, decode 1023 + 1). The window bound is unchanged for both. Each defaults to None, keeping the shared sizes.

The auxiliary model follows: decode_mask and decode_cache_update are traced from the decode config when either knob is set, and reuse the prefill builder when neither is.

Export-only: the LiteRT-LM runtime still shares one physical buffer per cache across signatures, so differing prefill/decode sizes are not yet runnable.