### PR TITLE
Preserve single-element structured outputs in the JAX bridge

### DIFF
--- a/litert_torch/backend/jax_bridge/_wrap.py
+++ b/litert_torch/backend/jax_bridge/_wrap.py
@@ -267,11 +267,24 @@ def wrap(jaxfn: Callable[Any, Any], ir_input_names: list[str] = None):
           ir.RankedTensorType.get(result.type.shape, target_elty), result
       )
 
-    if len(results) == 1:
+    if hasattr(out_avals, "dtype"):
+      if len(results) != 1:
+        raise RuntimeError(
+            "JAX lowering returned multiple results for a tensor-valued "
+            f"ATen output: {len(results)}"
+        )
       return sanitize_result_elty(results[0], out_avals)
-    return [
+
+    flat_out_avals, out_spec = pytree.tree_flatten(out_avals)
+    if len(results) != len(flat_out_avals):
+      raise RuntimeError(
+          "JAX lowering result count does not match the ATen output "
+          f"structure: {len(results)} != {len(flat_out_avals)}"
+      )
+    sanitized_results = [
         sanitize_result_elty(result, aval)
-        for result, aval in zip(results, out_avals)
+        for result, aval in zip(results, flat_out_avals)
     ]
+    return pytree.tree_unflatten(sanitized_results, out_spec)
 
   return wrapped

--- a/litert_torch/backend/jax_bridge/test/test_wrap.py
+++ b/litert_torch/backend/jax_bridge/test/test_wrap.py
@@ -19,6 +19,7 @@ from litert_torch import backend
 from litert_torch.backend import jax_bridge
 from litert_converter.mlir import ir
 from litert_converter.mlir.dialects import func
+import torch
 
 from absl.testing import absltest as googletest
 
@@ -79,6 +80,33 @@ class TestWrap(googletest.TestCase):
     ir_text = str(module)
     self.assertIn("%0 = call @retb_", ir_text)
     self.assertIn("return %arg0 : tensor<10x10xf32>", ir_text)
+
+  def test_wrap_preserves_single_element_list_output(self):
+    with (
+        backend.export_utils.create_ir_context() as context,
+        ir.Location.unknown(),
+    ):
+      module = ir.Module.create()
+      lctx = backend.export.LoweringContext(context, module)
+      graph = torch.fx.Graph()
+      lctx.node = graph.placeholder("output")
+      lctx.node.meta["val"] = [torch.empty((10, 10))]
+
+      @jax_bridge.wrap
+      def wrapped_list(a: jax.Array):
+        return [a]
+
+      with ir.InsertionPoint(module.body):
+
+        @func.FuncOp.from_py_func(
+            ir.RankedTensorType.get((10, 10), ir.F32Type.get()),
+            name="main",
+        )
+        def _main(a):
+          result = wrapped_list(lctx, a)
+          self.assertIsInstance(result, list)
+          self.assertLen(result, 1)
+          return result[0]
 
 
 if __name__ == "__main__":

--- a/litert_torch/backend/test/test_core_aten_ops.py
+++ b/litert_torch/backend/test/test_core_aten_ops.py
@@ -376,6 +376,7 @@ class TestCoreAtenOps(parameterized.TestCase):
       ("aten__softmax_0", torch.ops.aten._softmax, (rnd(torch.float32, (10, 10)), 1, False,), dict()),
       ("aten_split_copy_Tensor_0", torch.ops.aten.split_copy.Tensor, (rnd(torch.float32, (10, 10)), 2,), dict()),
       ("aten_split_with_sizes_0", torch.ops.aten.split_with_sizes, (rnd(torch.float32, (10, 10)), [1, 2, 3, 4],), dict()),
+      ("aten_split_with_sizes_single_output", torch.ops.aten.split_with_sizes, (rnd(torch.float32, (10, 10)), [10],), dict()),
       ("aten_sqrt_0", torch.ops.aten.sqrt, (rnd(torch.float32, (10, 10)),), dict()),
       ("aten_squeeze_copy_dim_0", torch.ops.aten.squeeze_copy.dim, (rnd(torch.float32, (10, 10)), 0,), dict()),
       ("aten_squeeze_dims_0", torch.ops.aten.squeeze.dims, (rnd(torch.float32, (10, 10)), [0, 1],), dict()),


### PR DESCRIPTION
## Summary

The JAX bridge currently treats every lowering with one MLIR result as a tensor-valued ATen output. This loses the output container for structured outputs with one element and passes the container itself to dtype sanitization.

This occurs during export of [RF-DETR](https://github.com/roboflow/rf-detr): its exported graph can contain `aten.split_with_sizes` with a single output, causing conversion to fail with `AttributeError: list object has no attribute dtype`.

Use the ATen output metadata to distinguish tensor outputs from pytrees, validate the flattened result count, and reconstruct the original output structure. Add focused bridge coverage and a `split_with_sizes` regression case with one output.

## Tests

- `python -m pytest litert_torch/backend/jax_bridge/test/test_wrap.py -vv`
- `pyink --check` on the changed files

The focused regression fails on `main` with `AttributeError: list object has no attribute dtype` and passes with this change.