### PR TITLE
Probe the chat template with a sentinel instead of searching the rendered output for the prompt

### DIFF
--- a/litert_torch/generative/export_hf/experimental/calib/quant_utils_test.py
+++ b/litert_torch/generative/export_hf/experimental/calib/quant_utils_test.py
@@ -174,6 +174,50 @@ class QuantUtilsChatTemplateTest(absltest.TestCase):
         "<start_of_turn>user\nHello error<end_of_turn>\n<start_of_turn>model\n",
     )
 
+  def test_format_chat_prompt_dropping_template_falls_back(self):
+    # SmolVLM2-style template: expects list-shaped content, so a plain string
+    # is dropped and only the template's own boilerplate is rendered.
+    mock_tx = mock.MagicMock()
+    mock_tx.chat_template = "some_template"
+    mock_tx.apply_chat_template.return_value = (
+        "<|im_start|>User: <end_of_utterance>\nAssistant:"
+    )
+
+    tok = tokenizer_lib.Tokenizer.__new__(tokenizer_lib.Tokenizer)
+    tok.spm = None
+    tok.tx_tokenizer = mock_tx
+    tok._image_preprocessor = None
+
+    res = quant_utils.get_example_prompt(
+        "Hello dropped", enable_formatting=True, tokenizer=tok
+    )
+    self.assertEqual(
+        res,
+        "<start_of_turn>user\nHello dropped<end_of_turn>\n<start_of_turn>model\n",
+    )
+
+  def test_format_chat_prompt_boilerplate_substring_prompt_falls_back(self):
+    # Regression: a prompt that happens to appear in the dropping template's
+    # own boilerplate ('User:') must not defeat the drop detection.
+    mock_tx = mock.MagicMock()
+    mock_tx.chat_template = "some_template"
+    mock_tx.apply_chat_template.return_value = (
+        "<|im_start|>User: <end_of_utterance>\nAssistant:"
+    )
+
+    tok = tokenizer_lib.Tokenizer.__new__(tokenizer_lib.Tokenizer)
+    tok.spm = None
+    tok.tx_tokenizer = mock_tx
+    tok._image_preprocessor = None
+
+    res = quant_utils.get_example_prompt(
+        {"text": "User:"}, enable_formatting=True, tokenizer=tok
+    )
+    self.assertEqual(
+        res,
+        "<start_of_turn>user\nUser:<end_of_turn>\n<start_of_turn>model\n",
+    )
+
   def test_tokenizer_loads_standalone_chat_template_json(self):
     temp_dir = self.create_tempdir().full_path
     template_data = {

--- a/litert_torch/generative/export_hf/experimental/calib/tokenizer.py
+++ b/litert_torch/generative/export_hf/experimental/calib/tokenizer.py
@@ -76,6 +76,13 @@ class TokenizerConfig:
 PROMPT_TEMPLATE_PREFIX = '<start_of_turn>user\n'
 PROMPT_TEMPLATE_SUFFIX = '<end_of_turn>\n<start_of_turn>model\n'
 
+# Sentinel used to probe whether a chat template preserves plain-string
+# content. Searching the rendered output for the prompt itself does not
+# detect a drop reliably: a prompt like 'User:' can be a substring of the
+# template's own boilerplate, so the search succeeds while the content is
+# gone.
+_CONTENT_PROBE = 'KIMAIRA_CALIBRATION_PROBE'
+
 
 class Tokenizer:
   """Tokenizes the input string."""
@@ -162,37 +169,37 @@ class Tokenizer:
       return prompt
 
     if self.tx_tokenizer and getattr(self.tx_tokenizer, 'chat_template', None):
-      try:
-        messages = (
-            prompt
-            if isinstance(prompt, list)
-            else [{'role': 'user', 'content': prompt}]
-        )
-        formatted = self.tx_tokenizer.apply_chat_template(
-            messages,
-            tokenize=False,
-            add_generation_prompt=True,
-        )
-        # Guard: Check that prompt text was not dropped (e.g. SmolVLM2 list schema)
-        raw_text = (
-            prompt
-            if isinstance(prompt, str)
-            else str(messages[-1].get('content', ''))
-        )
-        if isinstance(formatted, str) and (
-            not raw_text or raw_text in formatted
-        ):
-          return formatted
+      # Guard: probe the template with a sentinel before trusting it with the
+      # real prompt (e.g. SmolVLM2's list schema drops plain-string content).
+      if not self._chat_template_keeps_content():
         logging.warning(
-            'apply_chat_template dropped the prompt content; falling back to'
-            ' default formatting.'
+            'chat template does not preserve plain-string content; falling'
+            ' back to default formatting.'
         )
-      except Exception as e:  # pylint: disable=broad-exception-caught
-        logging.warning(
-            'Failed to apply chat template (%s); falling back to default'
-            ' formatting.',
-            e,
-        )
+      else:
+        try:
+          messages = (
+              prompt
+              if isinstance(prompt, list)
+              else [{'role': 'user', 'content': prompt}]
+          )
+          formatted = self.tx_tokenizer.apply_chat_template(
+              messages,
+              tokenize=False,
+              add_generation_prompt=True,
+          )
+          if isinstance(formatted, str):
+            return formatted
+          logging.warning(
+              'apply_chat_template did not return a string; falling back to'
+              ' default formatting.'
+          )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+          logging.warning(
+              'Failed to apply chat template (%s); falling back to default'
+              ' formatting.',
+              e,
+          )
 
     # Fallback when no chat template is available or template execution failed
     raw_str = (
@@ -201,6 +208,18 @@ class Tokenizer:
         else '\n'.join([str(m.get('content', '')) for m in prompt])
     )
     return PROMPT_TEMPLATE_PREFIX + raw_str + PROMPT_TEMPLATE_SUFFIX
+
+  def _chat_template_keeps_content(self) -> bool:
+    """Returns whether the chat template reproduces plain-string content."""
+    try:
+      rendered = self.tx_tokenizer.apply_chat_template(
+          [{'role': 'user', 'content': _CONTENT_PROBE}],
+          tokenize=False,
+          add_generation_prompt=True,
+      )
+    except Exception:  # pylint: disable=broad-exception-caught
+      return False
+    return isinstance(rendered, str) and _CONTENT_PROBE in rendered
 
   def tokenize_internal(self, input_string: str):
     """Tokenizes the input string."""


### PR DESCRIPTION
Follow-up to #1193 / #1181. The drop-guard in `Tokenizer.format_chat_prompt` checks whether the prompt string appears in the rendered output. That check has a blind spot my PR #1182's first commit shared and its second commit (81cf98e) fixed: when a template drops plain-string content (e.g. SmolVLM2's list schema), its boilerplate can happen to contain the prompt, so the check passes silently and that example calibrates on content-free boilerplate.

Concretely, with `HuggingFaceTB/SmolVLM2-500M-Video-Instruct`'s tokenizer at current main (70d7619), the calibration example `"User:"` comes back as `<|im_start|>User: <end_of_utterance>\nAssistant:` and is accepted. None of the 50 shipped calibration prompts can trigger this (all 50 checked against that boilerplate), so it only affects user-supplied calibration data with a template of that kind.

This PR ports the second commit's approach onto the new `format_chat_prompt` structure: probe the template once with a neutral sentinel string and check that the sentinel survives, instead of searching the output for the prompt. The diff is mostly re-indentation of the existing try block; the logic change is the probe plus dropping the substring comparison.

Verified:

- All 9 tests in `quant_utils_test.py` pass (7 existing + 2 added). The new regression test fails on current main and passes with this change.
- No behavior change on the shipped path: Stages 2-3 on `Qwen/Qwen3-0.6B` with the default `{"text": ...}` examples produce a quantized tflite byte-identical to current main's, sha256 `86481cad55d7a874e64faf85e401e591718b6e9a98e277205af3fd5a644684a7` — the known-good artifact from #1181.

Happy to adjust the shape to whatever is easiest to import.
