### PR TITLE
Write start_token only when the model input actually starts with the BOS

### DIFF
--- a/litert_torch/generative/export_hf/core/litert_lm_builder.py
+++ b/litert_torch/generative/export_hf/core/litert_lm_builder.py
@@ -116,6 +116,57 @@ def parse_chat_template(tokenizer):
     return (None, None), (None, None), (None, None)
 
 
+def _tokenizer_prepends_bos(tokenizer, chat_template=None) -> bool:
+  """Checks whether the model input actually starts with the BOS token.
+
+  A declared `bos_token` does not guarantee the model ever sees it: a
+  tokenizer with `add_bos_token: false` declares a BOS that HF-side
+  tokenization never prepends, and writing it as `start_token` makes the
+  runtime prepend a token the checkpoint never sees in that position. When
+  the BOS is also the EOS, the model reads the prompt as a finished document
+  and can degenerate into echoing it.
+
+  Two probes cover the ways the model input gets a BOS: plain tokenization
+  (covers `add_bos_token: true` and post-processors), and the rendered chat
+  template (covers templates that begin with the BOS, e.g. `{{ bos_token }}`
+  — the template prefix is stripped in parse_chat_template, or rendered
+  empty by the runtime's jinja engine, and restored from `start_token`, so
+  such models still need the field).
+
+  Args:
+    tokenizer: Tokenizer of the source model.
+    chat_template: The jinja chat template being shipped, when it is not
+      `tokenizer.chat_template` (e.g. jinja_chat_template_override).
+
+  Returns:
+    True if either probe yields the BOS token id first, or if the tokenizer
+    cannot be probed (preserving the previous behavior of trusting the
+    declared `bos_token`).
+  """
+  try:
+    input_ids = tokenizer('x').input_ids
+    bos_token_id = getattr(tokenizer, 'bos_token_id', None)
+    if bos_token_id is None and isinstance(tokenizer.bos_token, int):
+      bos_token_id = tokenizer.bos_token
+    if bos_token_id is None:
+      return False
+    if len(input_ids) > 0 and input_ids[0] == bos_token_id:
+      return True
+    chat_template = chat_template or getattr(tokenizer, 'chat_template', None)
+    if chat_template:
+      rendered = tokenizer.apply_chat_template(
+          [{'role': 'user', 'content': 'x'}],
+          chat_template=chat_template,
+          tokenize=False,
+          add_generation_prompt=False,
+      )
+      input_ids = tokenizer(rendered, add_special_tokens=False).input_ids
+      return len(input_ids) > 0 and input_ids[0] == bos_token_id
+    return False
+  except Exception:  # pylint: disable=broad-except
+    return True
+
+
 def build_llm_metadata(
     source_model_artifacts: export_lib.SourceModelArtifacts,
     export_config: exportable_module.ExportableModuleConfig,
@@ -130,7 +181,14 @@ def build_llm_metadata(
 
   llm_metadata = llm_metadata_pb2.LlmMetadata()
 
-  if hasattr(tokenizer, 'bos_token') and tokenizer.bos_token:
+  if (
+      hasattr(tokenizer, 'bos_token')
+      and tokenizer.bos_token
+      and _tokenizer_prepends_bos(
+          tokenizer,
+          chat_templates if isinstance(chat_templates, str) else None,
+      )
+  ):
     if isinstance(tokenizer.bos_token, int):
       llm_metadata.start_token.token_ids.ids.append(tokenizer.bos_token)
     elif isinstance(tokenizer.bos_token, str):

--- a/litert_torch/generative/export_hf/core/litert_lm_builder_test.py
+++ b/litert_torch/generative/export_hf/core/litert_lm_builder_test.py
@@ -18,7 +18,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 from litert_torch.generative.export_hf.core import export_lib
 from litert_torch.generative.export_hf.core import exportable_module
-from litert_torch.generative.export_hf.core import litert_lm_builder
+from litert_torch.generative.export_hf.core import litert_lm_builder as litertlm_builder
 
 _EMPTY_CHAT_TEMPLATES = ((None, None), (None, None), (None, None))
 
@@ -88,7 +88,7 @@ class _FakeModel:
 
 
 def _build_llm_metadata(tokenizer, chat_templates=_EMPTY_CHAT_TEMPLATES):
-  return litert_lm_builder.build_llm_metadata(
+  return litertlm_builder.build_llm_metadata(
       source_model_artifacts=export_lib.SourceModelArtifacts(
           model=_FakeModel(),
           model_config=None,
@@ -110,7 +110,7 @@ class TokenizerPrependsBosTest(parameterized.TestCase):
     tokenizer = _FakeTokenizer(
         bos_token="<s>", bos_token_id=1, prepends_bos=True
     )
-    self.assertTrue(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+    self.assertTrue(litertlm_builder._tokenizer_prepends_bos(tokenizer))
 
   def test_false_when_declared_bos_is_not_prepended(self):
     # add_bos_token: false checkpoints (e.g. granite-4.1) declare a BOS that
@@ -121,7 +121,7 @@ class TokenizerPrependsBosTest(parameterized.TestCase):
         prepends_bos=False,
         eos_token="<|end_of_text|>",
     )
-    self.assertFalse(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+    self.assertFalse(litertlm_builder._tokenizer_prepends_bos(tokenizer))
 
   def test_true_when_chat_template_carries_the_bos(self):
     # OLMo-2-style: tokenization never prepends the BOS, but the chat
@@ -134,7 +134,7 @@ class TokenizerPrependsBosTest(parameterized.TestCase):
         eos_token="<|endoftext|>",
         template_carries_bos=True,
     )
-    self.assertTrue(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+    self.assertTrue(litertlm_builder._tokenizer_prepends_bos(tokenizer))
 
   def test_false_when_chat_template_does_not_carry_the_bos(self):
     tokenizer = _FakeTokenizer(
@@ -144,7 +144,7 @@ class TokenizerPrependsBosTest(parameterized.TestCase):
         eos_token="<|end_of_text|>",
         template_carries_bos=False,
     )
-    self.assertFalse(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+    self.assertFalse(litertlm_builder._tokenizer_prepends_bos(tokenizer))
 
   def test_true_when_shipped_template_carries_the_bos(self):
     # jinja_chat_template_override case: the shipped template is not the
@@ -157,12 +157,12 @@ class TokenizerPrependsBosTest(parameterized.TestCase):
         eos_token="<|endoftext|>",
     )
     self.assertTrue(
-        litert_lm_builder._tokenizer_prepends_bos(
+        litertlm_builder._tokenizer_prepends_bos(
             tokenizer, "{{ bos_token }}<|user|>{{ content }}"
         )
     )
     self.assertFalse(
-        litert_lm_builder._tokenizer_prepends_bos(
+        litertlm_builder._tokenizer_prepends_bos(
             tokenizer, "<|user|>{{ content }}"
         )
     )
@@ -171,7 +171,7 @@ class TokenizerPrependsBosTest(parameterized.TestCase):
     tokenizer = _FakeTokenizer(
         bos_token="<s>", bos_token_id=None, prepends_bos=False
     )
-    self.assertFalse(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+    self.assertFalse(litertlm_builder._tokenizer_prepends_bos(tokenizer))
 
   def test_int_bos_token_used_as_id_when_id_attribute_is_missing(self):
     class _IntBosTokenizer:
@@ -182,13 +182,13 @@ class TokenizerPrependsBosTest(parameterized.TestCase):
         return _FakeEncoding([5, 7, 8])
 
     self.assertTrue(
-        litert_lm_builder._tokenizer_prepends_bos(_IntBosTokenizer())
+        litertlm_builder._tokenizer_prepends_bos(_IntBosTokenizer())
     )
 
   def test_true_when_tokenizer_cannot_be_probed(self):
     # Preserves the previous behavior for tokenizers we cannot call.
     self.assertTrue(
-        litert_lm_builder._tokenizer_prepends_bos(
+        litertlm_builder._tokenizer_prepends_bos(
             _UnprobeableTokenizer(bos_token="<s>")
         )
     )

--- a/litert_torch/generative/export_hf/core/litert_lm_builder_test.py
+++ b/litert_torch/generative/export_hf/core/litert_lm_builder_test.py
@@ -1,0 +1,261 @@
+# Copyright 2026 The LiteRT Torch Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for litert_lm_builder."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from litert_torch.generative.export_hf.core import export_lib
+from litert_torch.generative.export_hf.core import exportable_module
+from litert_torch.generative.export_hf.core import litert_lm_builder
+
+_EMPTY_CHAT_TEMPLATES = ((None, None), (None, None), (None, None))
+
+
+class _FakeEncoding:
+
+  def __init__(self, input_ids):
+    self.input_ids = input_ids
+
+
+class _FakeTokenizer:
+  """Minimal tokenizer stub for start_token gating tests."""
+
+  def __init__(
+      self,
+      bos_token,
+      bos_token_id,
+      prepends_bos,
+      eos_token="</s>",
+      template_carries_bos=None,
+  ):
+    self.bos_token = bos_token
+    self.bos_token_id = bos_token_id
+    self.eos_token = eos_token
+    # None: no chat template. True/False: template present, starting with the
+    # BOS or not (like the OLMo-2 `{{ bos_token }}...` vs granite templates).
+    self.chat_template = None
+    if template_carries_bos is not None:
+      prefix = "{{ bos_token }}" if template_carries_bos else ""
+      self.chat_template = prefix + "<|user|>{{ content }}"
+    self._prepends_bos = prepends_bos
+
+  def __call__(self, text, add_special_tokens=True):
+    ids = []
+    if add_special_tokens and self._prepends_bos:
+      ids.append(self.bos_token_id)
+    if isinstance(self.bos_token, str) and text.startswith(self.bos_token):
+      ids.append(self.bos_token_id)
+    ids.extend([7, 8])
+    return _FakeEncoding(ids)
+
+  def apply_chat_template(
+      self,
+      messages,
+      chat_template=None,
+      tokenize=False,
+      add_generation_prompt=False,
+  ):
+    template = (
+        chat_template if chat_template is not None else self.chat_template
+    )
+    rendered = template.replace("{{ bos_token }}", str(self.bos_token))
+    return rendered.replace("{{ content }}", messages[0]["content"])
+
+
+class _UnprobeableTokenizer:
+  """Tokenizer that cannot be called, e.g. a non-HF tokenizer."""
+
+  def __init__(self, bos_token, eos_token="</s>"):
+    self.bos_token = bos_token
+    self.eos_token = eos_token
+    self.chat_template = None
+
+
+class _FakeModel:
+  generation_config = None
+
+
+def _build_llm_metadata(tokenizer, chat_templates=_EMPTY_CHAT_TEMPLATES):
+  return litert_lm_builder.build_llm_metadata(
+      source_model_artifacts=export_lib.SourceModelArtifacts(
+          model=_FakeModel(),
+          model_config=None,
+          text_model_config=None,
+          tokenizer=tokenizer,
+      ),
+      export_config=exportable_module.ExportableModuleConfig(
+          model="test-model"
+      ),
+      chat_templates=chat_templates,
+      exported_model_artifacts=export_lib.ExportedModelArtifacts(),
+      litert_lm_model_type_override="generic",
+  )
+
+
+class TokenizerPrependsBosTest(parameterized.TestCase):
+
+  def test_true_when_bos_is_prepended(self):
+    tokenizer = _FakeTokenizer(
+        bos_token="<s>", bos_token_id=1, prepends_bos=True
+    )
+    self.assertTrue(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+
+  def test_false_when_declared_bos_is_not_prepended(self):
+    # add_bos_token: false checkpoints (e.g. granite-4.1) declare a BOS that
+    # tokenization never prepends.
+    tokenizer = _FakeTokenizer(
+        bos_token="<|end_of_text|>",
+        bos_token_id=100257,
+        prepends_bos=False,
+        eos_token="<|end_of_text|>",
+    )
+    self.assertFalse(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+
+  def test_true_when_chat_template_carries_the_bos(self):
+    # OLMo-2-style: tokenization never prepends the BOS, but the chat
+    # template begins with `{{ bos_token }}`. parse_chat_template strips that
+    # prefix on the assumption start_token restores it, so it must be kept.
+    tokenizer = _FakeTokenizer(
+        bos_token="<|endoftext|>",
+        bos_token_id=100257,
+        prepends_bos=False,
+        eos_token="<|endoftext|>",
+        template_carries_bos=True,
+    )
+    self.assertTrue(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+
+  def test_false_when_chat_template_does_not_carry_the_bos(self):
+    tokenizer = _FakeTokenizer(
+        bos_token="<|end_of_text|>",
+        bos_token_id=100257,
+        prepends_bos=False,
+        eos_token="<|end_of_text|>",
+        template_carries_bos=False,
+    )
+    self.assertFalse(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+
+  def test_true_when_shipped_template_carries_the_bos(self):
+    # jinja_chat_template_override case: the shipped template is not the
+    # tokenizer's own (which may not exist), so the gate must probe the
+    # template that is actually packaged.
+    tokenizer = _FakeTokenizer(
+        bos_token="<|endoftext|>",
+        bos_token_id=100257,
+        prepends_bos=False,
+        eos_token="<|endoftext|>",
+    )
+    self.assertTrue(
+        litert_lm_builder._tokenizer_prepends_bos(
+            tokenizer, "{{ bos_token }}<|user|>{{ content }}"
+        )
+    )
+    self.assertFalse(
+        litert_lm_builder._tokenizer_prepends_bos(
+            tokenizer, "<|user|>{{ content }}"
+        )
+    )
+
+  def test_false_when_bos_token_id_is_unresolvable(self):
+    tokenizer = _FakeTokenizer(
+        bos_token="<s>", bos_token_id=None, prepends_bos=False
+    )
+    self.assertFalse(litert_lm_builder._tokenizer_prepends_bos(tokenizer))
+
+  def test_int_bos_token_used_as_id_when_id_attribute_is_missing(self):
+    class _IntBosTokenizer:
+      bos_token = 5
+      eos_token = "</s>"
+
+      def __call__(self, text):
+        return _FakeEncoding([5, 7, 8])
+
+    self.assertTrue(
+        litert_lm_builder._tokenizer_prepends_bos(_IntBosTokenizer())
+    )
+
+  def test_true_when_tokenizer_cannot_be_probed(self):
+    # Preserves the previous behavior for tokenizers we cannot call.
+    self.assertTrue(
+        litert_lm_builder._tokenizer_prepends_bos(
+            _UnprobeableTokenizer(bos_token="<s>")
+        )
+    )
+
+
+class BuildLlmMetadataStartTokenTest(parameterized.TestCase):
+
+  def test_no_start_token_when_bos_is_not_prepended(self):
+    # Regression test for https://github.com/google-ai-edge/litert-torch/issues/1194:
+    # a bos == eos checkpoint with add_bos_token: false must not get a
+    # start_token, otherwise the runtime prepends the EOS to the first turn.
+    tokenizer = _FakeTokenizer(
+        bos_token="<|end_of_text|>",
+        bos_token_id=100257,
+        prepends_bos=False,
+        eos_token="<|end_of_text|>",
+    )
+    llm_metadata = _build_llm_metadata(tokenizer)
+    self.assertFalse(llm_metadata.HasField("start_token"))
+
+  def test_start_token_written_when_bos_is_prepended(self):
+    tokenizer = _FakeTokenizer(
+        bos_token="<s>", bos_token_id=1, prepends_bos=True
+    )
+    llm_metadata = _build_llm_metadata(tokenizer)
+    self.assertEqual(llm_metadata.start_token.token_str, "<s>")
+
+  def test_start_token_written_when_chat_template_carries_the_bos(self):
+    tokenizer = _FakeTokenizer(
+        bos_token="<|endoftext|>",
+        bos_token_id=100257,
+        prepends_bos=False,
+        eos_token="<|endoftext|>",
+        template_carries_bos=True,
+    )
+    llm_metadata = _build_llm_metadata(tokenizer)
+    self.assertEqual(llm_metadata.start_token.token_str, "<|endoftext|>")
+
+  def test_start_token_follows_the_shipped_jinja_template(self):
+    # A tokenizer with no template of its own, packaged with an override
+    # template: the BOS must follow the template actually shipped.
+    tokenizer = _FakeTokenizer(
+        bos_token="<|endoftext|>",
+        bos_token_id=100257,
+        prepends_bos=False,
+        eos_token="<|endoftext|>",
+    )
+    with_bos = _build_llm_metadata(
+        tokenizer, chat_templates="{{ bos_token }}<|user|>{{ content }}"
+    )
+    self.assertEqual(with_bos.start_token.token_str, "<|endoftext|>")
+    without_bos = _build_llm_metadata(
+        tokenizer, chat_templates="<|user|>{{ content }}"
+    )
+    self.assertFalse(without_bos.HasField("start_token"))
+
+  def test_start_token_written_when_tokenizer_cannot_be_probed(self):
+    llm_metadata = _build_llm_metadata(_UnprobeableTokenizer(bos_token="<s>"))
+    self.assertEqual(llm_metadata.start_token.token_str, "<s>")
+
+  def test_no_start_token_when_bos_token_is_missing(self):
+    tokenizer = _FakeTokenizer(
+        bos_token=None, bos_token_id=None, prepends_bos=False
+    )
+    llm_metadata = _build_llm_metadata(tokenizer)
+    self.assertFalse(llm_metadata.HasField("start_token"))
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
Refs #1194 — thanks for the quick look at the report and for inviting this PR.

`build_llm_metadata` wrote `start_token` from `tokenizer.bos_token` whenever the attribute was truthy. For a checkpoint that declares a BOS but is never fed one (granite-4.1: `add_bos_token: false`, BOS == EOS), the runtime then prepends the EOS to the first turn and the model can degenerate into echoing the question — measurements in #1194. This PR writes `start_token` only when the model input actually starts with the BOS.

**The gate** (`_tokenizer_prepends_bos`) probes two things, in order:

1. Plain tokenization — does `tokenizer('x').input_ids` start with `bos_token_id`? This is the probe from #1194; it covers `add_bos_token` and post-processor-managed BOS.
2. If not, the shipped chat template — does its rendered form, tokenized with `add_special_tokens=False`, start with `bos_token_id`? Some templates carry the BOS themselves (OLMo-2's begins with `{{ bos_token }}`; SmolLM2-Instruct's ChatML opens with `<|im_start|>`, which is its declared BOS). `parse_chat_template` strips that prefix — and the runtime renders the jinja `bos_token` variable as empty — on the assumption that `start_token` restores it, so these models must keep the field. The probe receives the template actually being packaged, so `jinja_chat_template_override` is honored.

A tokenizer that cannot be probed (calling it raises) keeps the previous behavior of trusting the declared `bos_token`.

**Why probe instead of reading `add_bos_token`.** The attribute is not ground truth: gemma-2 and gemma-3 tokenizers expose `add_bos_token == False` yet do prepend `<bos>` through their post-processor. An attribute-based gate would have dropped their `start_token`; the probe keeps it.

**Checked against real tokenizers** (transformers 5.15.1), comparing the gate's outcome with whether HF's own input starts with the BOS:

| tokenizer | HF input starts with BOS? | start_token after this PR |
|---|---|---|
| ibm-granite/granite-4.1-3b | no — `add_bos_token: false`, template starts `<\|start_of_role\|>` | removed (the #1194 fix) |
| HuggingFaceTB/SmolLM2-135M | no — BOS == EOS, never fed | removed |
| allenai/OLMo-2-0425-1B-Instruct | yes — template begins `{{ bos_token }}` | kept |
| HuggingFaceTB/SmolLM2-135M-Instruct | yes — ChatML template opens with the BOS | kept |
| google/gemma-3-270m | yes — tokenization prepends `<bos>` | kept |
| Llama-3.2-1B-Instruct (unsloth mirror) | yes — post-processor prepends | kept |
| Qwen/Qwen3-0.6B | no `bos_token` declared | unchanged (absent) |

The override path is covered too: a base checkpoint with no template of its own, packaged with a `{{ bos_token }}`-style override, keeps its `start_token`.

**Tests.** `litert_lm_builder_test.py` covers both directions: the BOS == EOS non-prepending shape must not get a `start_token` (fails on current main), and the prepending / template-carried / override shapes must keep it. One note: running the test file by path (`python .../litert_lm_builder_test.py`) trips a pre-existing name collision between `core/litert_lm_builder.py` and the `litert-lm-builder` pip package; `./run_tests.sh` and `python -m` invocations are unaffected.

Happy to reshape any of this — the probe, the fallback, or the tests — into whatever form is easiest to review.
