### PR TITLE
Point export_hf int4 docs/examples at the blockwise dynamic_wi4b32_afp32 recipe

### DIFF
--- a/litert_torch/generative/export_hf/experimental/npu_export/litert_lm_npu_export.ipynb
+++ b/litert_torch/generative/export_hf/experimental/npu_export/litert_lm_npu_export.ipynb
@@ -158,7 +158,7 @@
         "# --- Option A: Manual Property Overrides ---\n",
         "# Uncomment any lines below to manually override specific pipeline properties:\n",
         "# cfg.model_id = \"google/gemma-3-1b-it\"\n",
-        "# cfg.weight_quantization_recipe = \"dynamic_wi4_afp32\"\n",
+        "# cfg.weight_quantization_recipe = \"dynamic_wi4b32_afp32\"\n",
         "# cfg.use_float_input_output_normalizer = False\n",
         "\n",
         "# --- Option B: Save or Load Configuration from JSON ---\n",

--- a/litert_torch/generative/export_hf/experimental/npu_export/litert_lm_npu_export.ipynb
+++ b/litert_torch/generative/export_hf/experimental/npu_export/litert_lm_npu_export.ipynb
@@ -158,7 +158,7 @@
         "# --- Option A: Manual Property Overrides ---\n",
         "# Uncomment any lines below to manually override specific pipeline properties:\n",
         "# cfg.model_id = \"google/gemma-3-1b-it\"\n",
-        "# cfg.weight_quantization_recipe = \"dynamic_wi4b32_afp32\"\n",
+        "# cfg.weight_quantization_recipe = \"dynamic_wi4_afp32\"\n",
         "# cfg.use_float_input_output_normalizer = False\n",
         "\n",
         "# --- Option B: Save or Load Configuration from JSON ---\n",

--- a/litert_torch/generative/export_hf/export.py
+++ b/litert_torch/generative/export_hf/export.py
@@ -150,6 +150,8 @@ def export(
     prefill_lengths: The lengths of the prefill input, separated by comma.
     cache_length: The length of the cache.
     quantization_recipe: The quantization recipes to use, separated by comma.
+      For int4 weights, use the blockwise `dynamic_wi4b32_afp32`; the
+      channelwise `dynamic_wi4_afp32` can severely degrade small LLMs.
     enable_dynamic_shape: Whether to enable dynamic shape.
     enable_gpu_dynamic_prefill: Whether to enable GPU dynamic shapes (magic
       numbers) for prefill lengths.


### PR DESCRIPTION
Follow-up to #1068, implementing the docs-only option agreed there — thanks @marialyu for the proposal and @sirakiin for the green light. This points the export_hf int4 docs/examples at the blockwise `dynamic_wi4b32_afp32` instead of the channelwise `dynamic_wi4_afp32`, which can severely degrade small LLMs (Qwen3-0.6B on GSM8K, greedy: 0% channelwise vs 50% block32).

No behavior change — the two guidance spots:

- `export.py`: one sentence added to the `quantization_recipe` docstring, which `fire` surfaces as the CLI help.
- `litert_lm_npu_export.ipynb`: the commented recipe-override example now names the blockwise recipe.

Fixes #1068