### PR TITLE
tokenizer_to_sentencepiece: preserve byte-level BPE byte semantics

### DIFF
--- a/litert_torch/generative/tools/tokenizer_to_sentencepiece_lib.py
+++ b/litert_torch/generative/tools/tokenizer_to_sentencepiece_lib.py
@@ -88,6 +88,16 @@ _NORMALIZE_FUNCS = {
 }
 
 
+def _is_byte_level(tokenizer: transformers.PreTrainedTokenizer) -> bool:
+  """Returns True when the vocab is GPT-2 style byte-level.
+
+  In such a vocab the 256 byte tokens are single characters of the GPT-2
+  byte<->unicode table, e.g. the space byte 0x20 is spelled "Ġ".
+  """
+  vocab = tokenizer.get_vocab()
+  return "Ġ" in vocab and all(c in vocab for c in ("Ċ", "Ã", "Â"))
+
+
 def _add_token(
     token: str,
     id_: int,
@@ -98,15 +108,37 @@ def _add_token(
     normalize_tokens: str = "decode",
 ):
   """Adds a token to the SentencePieceModel protobuf with a derived type."""
-  unk_token = tokenizer.unk_token or tokenizer.pad_token or tokenizer.eos_token
-  if token == unk_token:
+  # Only the tokenizer's own unk_token may become the UNKNOWN piece. Falling
+  # back to pad/eos would type that token UNKNOWN, and SentencePiece then both
+  # emits its id for unencodable input and never matches its text in prompts.
+  unk_token = tokenizer.unk_token
+  if unk_token is not None and token == unk_token:
     type_ = spm_model.ModelProto.SentencePiece.UNKNOWN
-  elif token in tokenizer.special_tokens_map:
-    type_ = spm_model.ModelProto.SentencePiece.CONTROL
-    sp_model.trainer_spec.control_symbols.append(token)
-  elif token in tokenizer.get_added_vocab():
+  elif (
+      token in tokenizer.all_special_tokens
+      or token in tokenizer.get_added_vocab()
+  ):
+    # Special tokens must be USER_DEFINED: SentencePiece never matches CONTROL
+    # pieces in input text.
     type_ = spm_model.ModelProto.SentencePiece.USER_DEFINED
     sp_model.trainer_spec.user_defined_symbols.append(token)
+  elif (
+      len(token) == 1
+      and token in _BYTE_DECODE_MAP
+      and _is_byte_level(tokenizer)
+  ):
+    # A byte-level token stands for a byte, not for the character its GPT-2
+    # spelling happens to be. Emit it as a BYTE piece so that e.g. a
+    # standalone "é" does not encode to the 0xE9 byte token's id.
+    sp_model.pieces.add(
+        piece="<0x%02X>" % _BYTE_DECODE_MAP[token],
+        score=-id_,
+        type=spm_model.ModelProto.SentencePiece.BYTE,
+    )
+    counts[spm_model.ModelProto.SentencePiece.BYTE] = (
+        counts.get(spm_model.ModelProto.SentencePiece.BYTE, 0) + 1
+    )
+    return
   else:
     type_ = spm_model.ModelProto.SentencePiece.NORMAL
 
@@ -165,6 +197,14 @@ def _build_spm_model_from_tokenizer(
 
   id_to_token = {id: tk for tk, id in tokenizer.vocab.items()}
   tokens_seen = set(tokenizer.vocab.keys())
+  if _is_byte_level(tokenizer):
+    # The byte tokens become <0xXX> pieces, so their raw spellings (e.g. "é"
+    # for byte 0xE9) no longer occupy the surface space; a merged token that
+    # decodes to "é" keeps that surface instead of being dropped as a
+    # duplicate.
+    tokens_seen -= {
+        t for t in tokens_seen if len(t) == 1 and t in _BYTE_DECODE_MAP
+    }
   counts = {}
   for id_ in range(len(tokenizer.vocab)):
     _add_token(
@@ -175,6 +215,59 @@ def _build_spm_model_from_tokenizer(
         tokens_seen,
         counts,
         normalize_tokens,
+    )
+
+  if _is_byte_level(tokenizer):
+    sp_model.trainer_spec.byte_fallback = True
+    present = {
+        p.piece
+        for p in sp_model.pieces
+        if p.type == spm_model.ModelProto.SentencePiece.BYTE
+    }
+    missing = [b for b in range(256) if "<0x%02X>" % b not in present]
+    if missing:
+      # Some vocabs never learned a standalone token for a few bytes, but
+      # SentencePiece requires all 256 BYTE pieces when byte_fallback is on.
+      # Appended past the vocab, these pieces can only be emitted for bytes
+      # the original tokenizer cannot encode either.
+      logging.warning(
+          "%d byte tokens absent from the vocab;"
+          " appending BYTE pieces past the vocab: %s",
+          len(missing),
+          ["0x%02X" % b for b in missing],
+      )
+      for b in missing:
+        sp_model.pieces.add(
+            piece="<0x%02X>" % b,
+            score=0.0,
+            type=spm_model.ModelProto.SentencePiece.BYTE,
+        )
+  if not any(
+      p.type == spm_model.ModelProto.SentencePiece.UNKNOWN
+      for p in sp_model.pieces
+  ):
+    # SentencePiece requires an UNKNOWN piece. When the tokenizer has no
+    # unk_token, append a dedicated <unk> past the vocab instead of typing
+    # pad/eos as UNKNOWN. Some vocabs (e.g. Qwen2.5) contain a literal
+    # "<unk>" token without it being the unk_token, and SentencePiece
+    # rejects duplicate piece surfaces, so pick an unused name.
+    existing_pieces = {p.piece for p in sp_model.pieces}
+    unk_piece = "<unk>"
+    suffix = 0
+    while unk_piece in existing_pieces:
+      suffix += 1
+      unk_piece = "<unk_%d>" % suffix
+    sp_model.pieces.add(
+        piece=unk_piece,
+        score=0.0,
+        type=spm_model.ModelProto.SentencePiece.UNKNOWN,
+    )
+    sp_model.trainer_spec.unk_id = len(sp_model.pieces) - 1
+    sp_model.trainer_spec.unk_piece = unk_piece
+    logging.info(
+        "No unk_token: appended %s at id %d",
+        unk_piece,
+        sp_model.trainer_spec.unk_id,
     )
 
   logging.info("number of tokens: %d", len(sp_model.pieces))

--- a/litert_torch/generative/tools/tokenizer_to_sentencepiece_lib_test.py
+++ b/litert_torch/generative/tools/tokenizer_to_sentencepiece_lib_test.py
@@ -1,0 +1,244 @@
+# Copyright 2026 The LiteRT Torch Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tokenizer_to_sentencepiece_lib.
+
+The tests build a small GPT-2 style byte-level BPE tokenizer with the
+`tokenizers` library (no network access), convert it, and check that the
+SentencePiece model encodes exactly like the original tokenizer — in
+particular for the byte-level failure modes: standalone non-ASCII characters
+must not collapse to a byte token's id, characters without a piece must go
+through byte fallback instead of UNK, and special tokens must match in text
+as a single piece.
+"""
+
+import tokenizers
+from tokenizers import models as tokenizers_models
+from tokenizers import pre_tokenizers
+from tokenizers import decoders
+from tokenizers import trainers
+import transformers
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from litert_torch.generative.tools import tokenizer_to_sentencepiece_lib
+
+from sentencepiece import sentencepiece_model_pb2 as spm_model
+import sentencepiece as spm
+
+_PIECE_TYPE = spm_model.ModelProto.SentencePiece
+
+# Standalone characters U+00A1..U+017F (Latin-1 Supplement + Latin Extended-A).
+# The GPT-2 byte<->unicode table spells the 256 byte tokens with exactly these
+# code points (plus ASCII), which is where a byte token's id can shadow the
+# real character.
+_LATIN_SWEEP = [chr(c) for c in range(0xA1, 0x180)]
+
+_CORPUS = (
+    ["é", "és", "é là"] * 40
+    + ["café résumé naïve entrée Zürich señor über garçon"] * 30
+    + ["The quick brown fox jumps over the lazy dog."] * 30
+    + ["def f(x):\n    return x**2 + 1"] * 20
+    + ["2025 12345 3.14159 1,000,000"] * 20
+)
+
+
+def _build_tokenizer(
+    with_unk_token: bool = False,
+    with_literal_unk: bool = False,
+    dropped_alphabet_chars: tuple[str, ...] = (),
+) -> transformers.PreTrainedTokenizerFast:
+  """Trains a small byte-level BPE tokenizer in memory."""
+  tokenizer = tokenizers.Tokenizer(tokenizers_models.BPE())
+  tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+  tokenizer.decoder = decoders.ByteLevel()
+  special_tokens = ["<|endoftext|>", "<|im_start|>", "<|im_end|>"]
+  if with_unk_token or with_literal_unk:
+    special_tokens.append("<unk>")
+  alphabet = [
+      c
+      for c in pre_tokenizers.ByteLevel.alphabet()
+      if c not in dropped_alphabet_chars
+  ]
+  trainer = trainers.BpeTrainer(
+      vocab_size=384,
+      special_tokens=special_tokens,
+      initial_alphabet=alphabet,
+      show_progress=False,
+  )
+  tokenizer.train_from_iterator(_CORPUS, trainer)
+  return transformers.PreTrainedTokenizerFast(
+      tokenizer_object=tokenizer,
+      eos_token="<|im_end|>",
+      pad_token="<|endoftext|>",
+      unk_token="<unk>" if with_unk_token else None,
+      additional_special_tokens=["<|im_start|>"],
+  )
+
+
+def _convert(
+    tokenizer: transformers.PreTrainedTokenizerFast,
+) -> tuple[spm_model.ModelProto, spm.SentencePieceProcessor]:
+  """Converts the tokenizer and loads the result."""
+  serialized = tokenizer_to_sentencepiece_lib.convert(tokenizer)
+  proto = spm_model.ModelProto.FromString(serialized)
+  processor = spm.SentencePieceProcessor()
+  processor.LoadFromSerializedProto(serialized)
+  return proto, processor
+
+
+class TokenizerToSentencepieceLibTest(parameterized.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    cls.tokenizer = _build_tokenizer()
+    cls.proto, cls.processor = _convert(cls.tokenizer)
+
+  def _hf_ids(self, text: str) -> list[int]:
+    return self.tokenizer.encode(text, add_special_tokens=False)
+
+  def _spm_ids(self, text: str) -> list[int]:
+    return list(self.processor.Encode(text))
+
+  def test_byte_tokens_become_byte_pieces_with_byte_fallback(self):
+    self.assertTrue(self.proto.trainer_spec.byte_fallback)
+    byte_pieces = [
+        p.piece for p in self.proto.pieces if p.type == _PIECE_TYPE.BYTE
+    ]
+    self.assertLen(byte_pieces, 256)
+    self.assertCountEqual(byte_pieces, ["<0x%02X>" % b for b in range(256)])
+
+  def test_standalone_characters_encode_like_the_tokenizer(self):
+    mismatches = {
+        c: (self._hf_ids(c), self._spm_ids(c))
+        for c in _LATIN_SWEEP
+        if self._hf_ids(c) != self._spm_ids(c)
+    }
+    self.assertEmpty(mismatches)
+
+  # Multi-word strings with non-ASCII words can hit the merge-order
+  # approximation the module docstring describes (a BPE merge whose
+  # intermediate token crosses an UTF-8 character boundary has no piece
+  # surface), so the probes here stick to ASCII words, byte-fallback
+  # characters, and special tokens, whose encodings the conversion does
+  # guarantee.
+  @parameterized.named_parameters(
+      ("symbols", "20°C × 3 ½ — · Ω"),
+      ("emoji", "hello 😀🎉 ok"),
+      ("code", "def f(x): return x**2 + 1"),
+      ("digits", "2025 20250830 12345 3.14159 1,000,000 v2.1.0"),
+      ("chat", "<|im_start|>user\nWhat is the capital of France?<|im_end|>"),
+  )
+  def test_strings_encode_like_the_tokenizer(self, text):
+    self.assertEqual(self._hf_ids(text), self._spm_ids(text))
+
+  def test_unencodable_character_uses_byte_fallback_not_unk(self):
+    # No whole-character piece exists for this emoji, so without byte
+    # fallback it can only become the UNK piece.
+    ids = self._spm_ids("😀")
+    self.assertEqual(self._hf_ids("😀"), ids)
+    self.assertNotIn(self.proto.trainer_spec.unk_id, ids)
+
+  def test_special_tokens_match_as_a_single_piece(self):
+    for token in ("<|im_end|>", "<|im_start|>", "<|endoftext|>"):
+      token_id = self.tokenizer.convert_tokens_to_ids(token)
+      self.assertEqual([token_id], self._spm_ids(token))
+      self.assertEqual(
+          _PIECE_TYPE.USER_DEFINED, self.proto.pieces[token_id].type
+      )
+
+  def test_no_unk_token_appends_dedicated_unk_past_the_vocab(self):
+    # The tokenizer has pad and eos but no unk_token: neither may be typed
+    # UNKNOWN, and the appended <unk> must live past the original vocab.
+    vocab_size = len(self.tokenizer.get_vocab())
+    unknown_ids = [
+        i
+        for i, p in enumerate(self.proto.pieces)
+        if p.type == _PIECE_TYPE.UNKNOWN
+    ]
+    self.assertLen(unknown_ids, 1)
+    self.assertGreaterEqual(unknown_ids[0], vocab_size)
+    self.assertEqual("<unk>", self.proto.pieces[unknown_ids[0]].piece)
+    self.assertEqual(unknown_ids[0], self.proto.trainer_spec.unk_id)
+
+  def test_unk_token_stays_the_unknown_piece(self):
+    tokenizer = _build_tokenizer(with_unk_token=True)
+    proto, _ = _convert(tokenizer)
+    unk_id = tokenizer.convert_tokens_to_ids("<unk>")
+    self.assertEqual(_PIECE_TYPE.UNKNOWN, proto.pieces[unk_id].type)
+    self.assertEqual(unk_id, proto.trainer_spec.unk_id)
+    unknown_ids = [
+        i for i, p in enumerate(proto.pieces) if p.type == _PIECE_TYPE.UNKNOWN
+    ]
+    self.assertEqual([unk_id], unknown_ids)
+
+  def test_literal_unk_in_vocab_does_not_collide_with_appended_unk(self):
+    # Qwen2.5-style vocab: no unk_token, but a literal "<unk>" token exists
+    # in the vocab. SentencePiece rejects duplicate piece surfaces, so the
+    # appended UNKNOWN piece must take an unused name.
+    tokenizer = _build_tokenizer(with_literal_unk=True)
+    self.assertIsNone(tokenizer.unk_token)
+    proto, processor = _convert(tokenizer)  # raises on a duplicate surface
+    unknown_ids = [
+        i for i, p in enumerate(proto.pieces) if p.type == _PIECE_TYPE.UNKNOWN
+    ]
+    self.assertLen(unknown_ids, 1)
+    self.assertEqual("<unk_1>", proto.pieces[unknown_ids[0]].piece)
+    self.assertEqual(unknown_ids[0], proto.trainer_spec.unk_id)
+    # The literal "<unk>" token keeps its own id and still matches in text.
+    literal_id = tokenizer.convert_tokens_to_ids("<unk>")
+    self.assertEqual([literal_id], list(processor.Encode("<unk>")))
+
+  def test_missing_byte_tokens_are_appended_past_the_vocab(self):
+    # Some vocabs never learned a standalone token for a few bytes (invalid
+    # UTF-8 lead bytes like 0xC0/0xC1 never occur in training text), but
+    # SentencePiece requires all 256 BYTE pieces when byte_fallback is on.
+    byte_to_unicode = {
+        b: c
+        for b, c in tokenizer_to_sentencepiece_lib._bytes_to_unicode().items()
+    }
+    dropped = (byte_to_unicode[0xC0], byte_to_unicode[0xC1])
+    tokenizer = _build_tokenizer(dropped_alphabet_chars=dropped)
+    vocab = tokenizer.get_vocab()
+    self.assertNotIn(dropped[0], vocab)
+    proto, processor = _convert(tokenizer)
+    byte_pieces = [p.piece for p in proto.pieces if p.type == _PIECE_TYPE.BYTE]
+    self.assertLen(byte_pieces, 256)
+    appended = [
+        p.piece for p in list(proto.pieces)[len(vocab) :]
+        if p.type == _PIECE_TYPE.BYTE
+    ]
+    self.assertCountEqual(["<0xC0>", "<0xC1>"], appended)
+    # The model still loads and encodes normal text identically.
+    text = "The quick brown fox jumps over the lazy dog."
+    self.assertEqual(
+        tokenizer.encode(text, add_special_tokens=False),
+        list(processor.Encode(text)),
+    )
+
+  def test_merged_accented_token_keeps_its_surface(self):
+    # The corpus trains a standalone token for "é", whose surface must not be
+    # dropped as a duplicate of the 0xE9 byte token's GPT-2 spelling. A
+    # standalone "é" then encodes to that token's id, exactly like the
+    # original tokenizer — not to the byte token's id and not to two byte
+    # fallback pieces.
+    hf_ids = self._hf_ids("é")
+    self.assertLen(hf_ids, 1)
+    self.assertEqual(hf_ids, self._spm_ids("é"))
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
Thanks for the quick turnaround on #1205 — here is the implementation, with the issue's measurements re-run on this branch and a self-contained test the suite can run.

**The change** — one commit, all in `_add_token` / `_build_spm_model_from_tokenizer`:

1. **The 256 byte tokens become `<0xXX>` BYTE pieces, and `byte_fallback` is on.** A vocab is treated as byte-level when it carries the GPT-2 byte↔unicode alphabet (`Ġ`, `Ċ`, `Ã`, `Â`). With the byte tokens' single-character spellings out of the surface space, a merged token that decodes to "é" keeps that surface instead of being dropped as a duplicate. Byte pieces the vocab never learned are appended past the vocab — SentencePiece requires all 256 when `byte_fallback` is set, and the appended ones can only be emitted for bytes the original tokenizer cannot encode either. (The SmolLM2-family vocab in the table below lacks 21 of the 256.)
2. **Only the tokenizer's own `unk_token` is typed UNKNOWN.** The pad/eos fallback is gone; when there is no unk_token, a dedicated UNKNOWN piece is appended past the vocab. One wrinkle surfaced while porting: Qwen2.5's vocab holds a literal `"<unk>"` token (id 128244) that is not its unk_token, and sentencepiece 0.2.2 rejects duplicate piece surfaces at load — so the appended piece takes the first unused name (`<unk_1>` there).
3. **Special tokens are USER_DEFINED, never CONTROL**, so SentencePiece matches them in input text.

For a vocab that is not byte-level, only 2 and 3 apply. The vocab_file copy path is untouched.

**Re-measured on this branch** (sentencepiece 0.2.2, transformers 5.14.1): encoding each of the 223 standalone characters U+00A1–U+017F and every added token with the converted proto, against the same tokenizer:

| model | mismatched characters | of which → UNK | special tokens split |
|---|---|---|---|
| HuggingFaceTB/SmolLM3-3B | 198/223 → **0** | 71 → 0 | `<\|im_end\|>` → none |
| Qwen/Qwen2.5-0.5B-Instruct | 163/223 → **0** | 36 → 0 | `<\|endoftext\|>` → none |
| HuggingFaceTB/SmolVLM2-500M-Video-Instruct | 204/223 → **0** | 92 → 0 | `<\|endoftext\|>` → * |
| mistralai/Ministral-3-3B-Reasoning-2512 | 196/223 → **0** | 69 → 0 | `<unk>` → * |

\* remains unmatchable because that token **is** the tokenizer's unk_token, so its piece stays UNKNOWN — by design.

**The test** (`tokenizer_to_sentencepiece_lib_test.py`) needs no network and no checkpoints: it trains a small byte-level BPE tokenizer in-process with the `tokenizers` library and checks that the converted proto encodes exactly like it — the 223-character sweep, byte fallback instead of UNK for characters without a piece, special tokens matching as a single piece, the appended-`<unk>` name collision, and the appended missing byte pieces. Its probe strings stay within what the conversion guarantees; the merge-order approximation described in the module docstring is unchanged and out of scope here.

Happy to reshape any of this — the byte-level detection heuristic, the piece naming, or the test's shape — to whatever fits the tree best.

Fixes #1205
