### PR TITLE
Derive prompt_templates.model.prefix from the generation prompt

### DIFF
--- a/litert_torch/generative/export_hf/core/litert_lm_builder.py
+++ b/litert_torch/generative/export_hf/core/litert_lm_builder.py
@@ -48,7 +48,19 @@ _STOP_TOKEN_PREFIXES = [
 
 
 def parse_chat_template(tokenizer):
-  """Parses chat template."""
+  """Parses the chat template into (system, user, model) (prefix, suffix) pairs.
+
+  Each pair is what the template renders around that role's content. The
+  model prefix is the generation prompt (`add_generation_prompt=True`): the
+  runtime sends `prompt_templates.model.prefix` after every user turn to
+  start the model's reply, so it must be the string the template renders at
+  generation time, not the opening of an assistant turn in history. See
+  `_generation_prompt`.
+
+  Returns:
+    None if the tokenizer has no chat template; a tuple of three
+    `[prefix, suffix]` lists, each `[None, None]` when parsing failed.
+  """
   if tokenizer.chat_template is None:
     return None
   try:
@@ -107,6 +119,9 @@ def parse_chat_template(tokenizer):
           f'Model prompt {_PH} not found in chat template:'
           f' {model_prompt_substr}'
       )
+    model_prompt_parts[0] = _generation_prompt(
+        tokenizer, messages[:-1], user_prompt, model_prompt_parts[0]
+    )
     return sys_prompt_parts, user_prompt_parts, model_prompt_parts
   except ValueError as e:
     print(f'Failed to parse chat template: {e}')
@@ -114,6 +129,62 @@ def parse_chat_template(tokenizer):
   except Exception as e:  # pylint: disable=broad-except
     print(f'Failed to parse chat template: {e}')
     return (None, None), (None, None), (None, None)
+
+
+def _generation_prompt(tokenizer, messages, user_prompt, history_prefix):
+  """Returns the assistant prefix the chat template renders at generation time.
+
+  The runtime appends `prompt_templates.model.prefix` after every user turn
+  as the generation prompt, i.e. the string `apply_chat_template(...,
+  add_generation_prompt=True)` adds after the last user turn. For most
+  templates that is the same string that opens an assistant turn in history,
+  but thinking templates diverge there: Qwen3-*-Thinking-2507 opens a
+  generation with `<think>\n` and renders a past assistant turn with the
+  reasoning already closed (`<think>\n\n</think>\n\n`). A prefix read from
+  the history turn then tells the model its thinking is over before it
+  started, and the reasoning spills into the answer text.
+
+  Args:
+    tokenizer: Tokenizer whose chat template is being parsed.
+    messages: The conversation up to and including the last user turn.
+    user_prompt: `messages` rendered with `add_generation_prompt=False`.
+    history_prefix: The prefix of an assistant turn rendered in history; used
+      when the template cannot render a generation prompt.
+
+  Returns:
+    The generation prompt, or `history_prefix` when the template does not
+    render one (renders nothing after the user turn, does not extend the
+    user rendering, or raises).
+  """
+  try:
+    rendered = tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        enable_thinking=False,
+        add_generation_prompt=True,
+    )
+  except Exception as e:  # pylint: disable=broad-except
+    print(
+        f'WARNING: Cannot render the generation prompt ({e}); using the'
+        f' assistant history prefix {history_prefix!r} as model prefix.'
+    )
+    return history_prefix
+  if not rendered.startswith(user_prompt) or rendered == user_prompt:
+    print(
+        'WARNING: Chat template renders no generation prompt after the user'
+        f' turn; using the assistant history prefix {history_prefix!r} as'
+        ' model prefix.'
+    )
+    return history_prefix
+  generation_prefix = rendered[len(user_prompt) :]
+  if generation_prefix != history_prefix:
+    print(
+        f'Chat template opens a generation with {generation_prefix!r} but an'
+        f' assistant turn in history with {history_prefix!r}; using the'
+        ' generation prompt as model prefix. The runtime renders past'
+        ' assistant turns from the same prefix.'
+    )
+  return generation_prefix
 
 
 def _tokenizer_prepends_bos(tokenizer, chat_template=None) -> bool:

--- a/litert_torch/generative/export_hf/core/litert_lm_builder_test.py
+++ b/litert_torch/generative/export_hf/core/litert_lm_builder_test.py
@@ -85,6 +85,60 @@ class _UnprobeableTokenizer:
     self.chat_template = None
 
 
+class _FakeChatMlTokenizer:
+  """ChatML tokenizer stub whose assistant opener depends on the render mode.
+
+  Thinking templates render an assistant turn differently in history and at
+  generation time: Qwen3-*-Thinking-2507 opens a generation with `<think>\n`
+  but renders a past turn with the reasoning closed (`<think>\n\n</think>\n\n`).
+  `history_opener` / `generation_opener` reproduce that shape.
+  """
+
+  bos_token = None
+  eos_token = "<|im_end|>"
+
+  def __init__(
+      self,
+      history_opener="",
+      generation_opener=None,
+      renders_generation_prompt=True,
+  ):
+    self.chat_template = "<jinja>"  # Present; the stub renders in Python.
+    self._history_opener = history_opener
+    self._generation_opener = (
+        history_opener if generation_opener is None else generation_opener
+    )
+    self._renders_generation_prompt = renders_generation_prompt
+
+  def apply_chat_template(
+      self,
+      messages,
+      tokenize=False,
+      add_generation_prompt=False,
+      **kwargs,
+  ):
+    del tokenize, kwargs
+    rendered = ""
+    for message in messages:
+      opener = self._history_opener if message["role"] == "assistant" else ""
+      rendered += (
+          f"<|im_start|>{message['role']}\n{opener}{message['content']}"
+          "<|im_end|>\n"
+      )
+    if add_generation_prompt and self._renders_generation_prompt:
+      rendered += f"<|im_start|>assistant\n{self._generation_opener}"
+    return rendered
+
+
+class _RaisingOnGenerationPromptTokenizer(_FakeChatMlTokenizer):
+  """Template that fails to render with add_generation_prompt=True."""
+
+  def apply_chat_template(self, messages, add_generation_prompt=False, **kw):
+    if add_generation_prompt:
+      raise ValueError("add_generation_prompt is not supported")
+    return super().apply_chat_template(messages, **kw)
+
+
 class _FakeModel:
   generation_config = None
 
@@ -281,6 +335,82 @@ class BuildLlmMetadataStartTokenTest(parameterized.TestCase):
         source_artifacts, export_config, "", exported_artifacts
     )
     self.assertTrue(metadata.llm_model_type.HasField("qwen3"))
+
+
+class ParseChatTemplateTest(parameterized.TestCase):
+
+  def test_model_prefix_is_the_generation_prompt(self):
+    # Regression test for https://github.com/google-ai-edge/litert-torch/issues/1209:
+    # the runtime sends model.prefix as the generation prompt, so it must be
+    # what the template renders with add_generation_prompt=True, not the
+    # opening of an assistant turn in history (Qwen3-*-Thinking-2507 shape).
+    tokenizer = _FakeChatMlTokenizer(
+        history_opener="<think>\n\n</think>\n\n", generation_opener="<think>\n"
+    )
+    system, user, model = litert_lm_builder.parse_chat_template(tokenizer)
+    self.assertEqual(system, ["<|im_start|>system\n", "<|im_end|>\n"])
+    self.assertEqual(user, ["<|im_start|>user\n", "<|im_end|>\n"])
+    self.assertEqual(
+        model, ["<|im_start|>assistant\n<think>\n", "<|im_end|>\n"]
+    )
+
+  def test_model_prefix_unchanged_when_history_and_generation_agree(self):
+    # Plain ChatML (and hybrid Qwen3 with enable_thinking=False): the history
+    # opener is the generation prompt, so the parse is unchanged.
+    tokenizer = _FakeChatMlTokenizer()
+    _, _, model = litert_lm_builder.parse_chat_template(tokenizer)
+    self.assertEqual(model, ["<|im_start|>assistant\n", "<|im_end|>\n"])
+
+  def test_model_prefix_falls_back_to_history_when_no_generation_prompt(self):
+    # A template that ignores add_generation_prompt renders nothing after the
+    # user turn; the history opener is the only prefix available.
+    tokenizer = _FakeChatMlTokenizer(
+        history_opener="<think></think>", renders_generation_prompt=False
+    )
+    _, _, model = litert_lm_builder.parse_chat_template(tokenizer)
+    self.assertEqual(
+        model, ["<|im_start|>assistant\n<think></think>", "<|im_end|>\n"]
+    )
+
+  def test_model_prefix_falls_back_to_history_when_render_raises(self):
+    # Rendering the generation prompt must not turn a parseable template into
+    # the all-None result that drops prompt_templates from the metadata.
+    tokenizer = _RaisingOnGenerationPromptTokenizer(
+        history_opener="<think></think>"
+    )
+    system, user, model = litert_lm_builder.parse_chat_template(tokenizer)
+    self.assertEqual(system, ["<|im_start|>system\n", "<|im_end|>\n"])
+    self.assertEqual(user, ["<|im_start|>user\n", "<|im_end|>\n"])
+    self.assertEqual(
+        model, ["<|im_start|>assistant\n<think></think>", "<|im_end|>\n"]
+    )
+
+  def test_no_chat_template(self):
+    tokenizer = _FakeChatMlTokenizer()
+    tokenizer.chat_template = None
+    self.assertIsNone(litert_lm_builder.parse_chat_template(tokenizer))
+
+
+class BuildLlmMetadataPromptTemplatesTest(parameterized.TestCase):
+
+  def test_model_prefix_written_from_the_generation_prompt(self):
+    tokenizer = _FakeChatMlTokenizer(
+        history_opener="<think>\n\n</think>\n\n", generation_opener="<think>\n"
+    )
+    llm_metadata = _build_llm_metadata(
+        tokenizer,
+        chat_templates=litert_lm_builder.parse_chat_template(tokenizer),
+    )
+    self.assertEqual(
+        llm_metadata.prompt_templates.model.prefix,
+        "<|im_start|>assistant\n<think>\n",
+    )
+    self.assertEqual(llm_metadata.prompt_templates.model.suffix, "<|im_end|>\n")
+    self.assertEqual(
+        llm_metadata.prompt_templates.user.prefix, "<|im_start|>user\n"
+    )
+    stop_tokens = [t.token_str for t in llm_metadata.stop_tokens]
+    self.assertIn("<|im_end|>\n", stop_tokens)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #1209 — thanks for the quick look at the report and for inviting this PR.

`parse_chat_template` derived `prompt_templates.model.prefix` from an assistant turn rendered in history (`add_generation_prompt=False`) and never rendered the generation prompt. LiteRT-LM sends that prefix after every user turn as the generation prompt ([`session_utils.cc#L118-L120`](https://github.com/google-ai-edge/LiteRT-LM/blob/3cf487a7be8a7c4d183a56c101f65b1d569d197a/runtime/core/session_utils.cc#L118-L120), [`model_type_utils.cc#L480-L488`](https://github.com/google-ai-edge/LiteRT-LM/blob/3cf487a7be8a7c4d183a56c101f65b1d569d197a/runtime/util/model_type_utils.cc#L480-L488)), so a thinking template's bundle opened every reply with a scaffold the template never produces at generation time. This PR renders the conversation once more with `add_generation_prompt=True` and takes what the template adds after the user turn as the model prefix.

**What changes.** `_generation_prompt` renders the system + user messages with `add_generation_prompt=True` and returns the part after the user turn; `parse_chat_template` uses it as the model prefix. The suffix is still read from the history turn. `enable_thinking` stays `False` in every render, as before, so hybrid templates keep exporting in non-thinking mode. When the template renders no generation prompt (nothing after the user turn, a rendering that does not extend the user turn, or an exception), the history-derived prefix is kept, so no template that parses today stops parsing. When the two strings differ, the export prints which one was used.

**Checked against real tokenizers** (transformers 5.14.1; `parse_chat_template` on main `a3fa185` vs this branch; "vendor" = the template's `add_generation_prompt=True` rendering minus the same render without it, at `enable_thinking=False`, the exporter's own mode):

| tokenizer | vendor generation prompt | `model.prefix` on main | with this PR |
|---|---|---|---|
| Qwen/Qwen3-4B-Thinking-2507 | `<\|im_start\|>assistant\n<think>\n` | `<\|im_start\|>assistant\n<think>\n\n</think>\n\n` | the vendor string |
| deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | `<｜Assistant｜><think>\n` | `<｜Assistant｜>` | the vendor string |
| openai/gpt-oss-20b | `<\|start\|>assistant` | `<\|start\|>assistant<\|channel\|>final<\|message\|>` | the vendor string |
| Qwen/Qwen3-4B, Qwen/Qwen3-0.6B (hybrid) | `<\|im_start\|>assistant\n<think>\n\n</think>\n\n` | same | unchanged |
| ibm-granite/granite-4.2-3b | `<\|im_start\|>assistant\n<think></think>` | same | unchanged |
| HuggingFaceTB/SmolLM3-3B | `<\|im_start\|>assistant\n<think>\n\n</think>\n` | same | unchanged |
| Qwen3-4B-Instruct-2507, SmolLM2-135M-Instruct, LFM2-350M, Llama-3.2-1B-Instruct, OLMo-2-0425-1B-Instruct, gemma-3-1b-it | their plain assistant opener | same | unchanged |
| microsoft/Phi-4-mini-instruct | — | fails to parse (`Cannot guess user prompt`) | same failure |

Three prefixes change, each to the string its template renders with `add_generation_prompt=True`; the other eleven are byte-identical to main, and the suffix is unchanged for all fourteen.

**What the prefix costs at runtime**, restated from #1209 (the published bundles with only `model.prefix` rewritten, litert-lm-api 0.16.1, macOS GPU, greedy, `max_output_tokens` 2048, three prompts):

| bundle | `model.prefix` | thought channel (chars, 3 prompts) | answer text |
|---|---|---|---|
| litert-community/Qwen3-4B-Thinking-2507 | `…assistant\n<think>\n` — what this PR writes | 803 / 3398 / 1385 | clean answer |
| same | `…assistant\n<think>\n\n</think>\n\n` — what main writes | 0 / 0 / 0 | the reasoning, a stray `</think>`, then the answer (991 / 4844 / 2116 chars) |
| litert-community/granite-4.2-3b (int4) | `…assistant\n<think>\n` — the vendor default, `enable_thinking` unset | 262 / 7201 / 1042 | clean answer (the GSM8K chain hit the 2048 cap inside the channel) |
| same | `…assistant\n<think></think>` — main and this PR, `enable_thinking=False` | 0 / 0 / 0 | direct answer, no reasoning |

The granite rows are the part this PR does not close: with `enable_thinking=False` its generation prompt is the no-think scaffold, and the exporter renders every template that way. Exposing `enable_thinking` as an export option is the separate change (shape (b) in the issue); I'd be glad to send it if that direction fits.

**Tests.** `litert_lm_builder_test.py` gains a ChatML stub whose assistant opener differs between history and generation, mirroring the Thinking-2507 shape. `test_model_prefix_is_the_generation_prompt` and `test_model_prefix_written_from_the_generation_prompt` fail on main and pass here; the fallback paths (template ignores `add_generation_prompt`, render raises) and the unchanged plain-ChatML case are covered too. Run as `python -m litert_torch.generative.export_hf.core.litert_lm_builder_test` (21 tests).

Related: #1206 (the thought channel is not declared on this path, so a `<think>` prefix has no channel to land in until it is) and google-ai-edge/LiteRT-LM#3445 (the runtime re-renders past assistant turns from the same prefix).

Thanks again for the invitation. Happy to reshape any of this — the fallback rules, the printed message, or the tests — into whatever form is easiest to review.

