### PR TITLE
npu_export: document the Qualcomm HTP prefill-mask size limit and warn when cache_length crosses it

### DIFF
--- a/litert_torch/generative/export_hf/experimental/npu_export/config_manager.py
+++ b/litert_torch/generative/export_hf/experimental/npu_export/config_manager.py
@@ -20,9 +20,20 @@ import json
 import os
 from typing import Any
 
+from absl import logging
 from litert_torch.generative.export_hf.experimental.npu_export.configs import vendor_configs
 
 gfile = None
+
+# Qualcomm HTP: an int16 ADD that reads a CONCATENATION output larger than
+# 1 MiB pairs its rows with the wrong operand rows (litert-torch#1184). The
+# prefill graph's attention-mask ADD reads exactly such a tensor - the mask
+# tiled over the query heads, 2 B x num_attention_heads x prefill x
+# (cache_length + prefill). Above the limit prefill is no longer causal and a
+# prompt longer than one prefill chunk loses its content (LiteRT-LM#3508); well
+# over the limit even one-chunk prompts come out as garbage (the same
+# non-causal-prefill defect, litert-torch#1184).
+_HTP_MASK_ADD_LIMIT_BYTES = 1 << 20
 
 
 def _open(path: str, mode: str = "r"):
@@ -157,7 +168,9 @@ def build_pipeline_config(
     target_vendor: Key in VENDOR_CONFIGS (e.g. 'qualcomm').
     target_soc: Target SoC ID (e.g. 'sm8850'). Validated against supported SoCs.
     prefill_lengths: User-specified prefill sequence buckets.
-    cache_length: User-specified KV cache capacity.
+    cache_length: User-specified KV cache capacity. On Qualcomm targets keep
+      2 B x num_attention_heads x prefill x (cache_length + prefill) at or
+      under 1 MiB - see warn_if_prefill_mask_exceeds_htp_limit.
     max_calibration_decode_steps: User-specified calibration decode sample
       steps.
     **user_overrides: Additional ad-hoc property overrides for
@@ -215,4 +228,53 @@ def build_pipeline_config(
   for k, v in merged.items():
     if k not in valid_fields and v is not None and k != "a16w8":
       setattr(cfg, k, v)
+  warn_if_prefill_mask_exceeds_htp_limit(cfg)
   return cfg
+
+
+def _prefill_mask_add_bytes(cfg: NpuPipelineConfig) -> tuple[int, int] | None:
+  """Returns (num_attention_heads, bytes of the prefill mask ADD operand)."""
+  if not cfg.prefill_lengths:
+    return None
+  try:
+    import transformers  # pylint: disable=g-import-not-at-top
+
+    hf_cfg = transformers.AutoConfig.from_pretrained(cfg.model_id)
+    # multimodal configs (gemma-3-4b and up) keep the text fields one level down
+    hf_cfg = getattr(hf_cfg, "text_config", hf_cfg)
+    heads = int(hf_cfg.num_attention_heads)
+    prefill = int(max(cfg.prefill_lengths))
+  except Exception:  # pylint: disable=broad-except
+    return None  # best effort: the export itself loads the config again
+  return heads, 2 * heads * prefill * (cfg.cache_length + prefill)
+
+
+def warn_if_prefill_mask_exceeds_htp_limit(cfg: NpuPipelineConfig) -> None:
+  """Warns when the prefill attention-mask ADD would exceed the HTP 1 MiB line."""
+  if cfg.backend != "qualcomm":
+    return
+  got = _prefill_mask_add_bytes(cfg)
+  if got is None:
+    return
+  heads, nbytes = got
+  if nbytes <= _HTP_MASK_ADD_LIMIT_BYTES:
+    return
+  prefill = int(max(cfg.prefill_lengths))
+  # the cache must hold more than one prefill bucket (cache_length == prefill
+  # does not build), so the hint needs safe > prefill
+  safe = _HTP_MASK_ADD_LIMIT_BYTES // (2 * heads * prefill) - prefill
+  hint = (
+      f"largest cache_length under the limit at prefill {prefill}: {safe}"
+      if safe > prefill
+      else f"no cache_length fits {heads} heads at prefill {prefill}"
+  )
+  logging.warning(
+      "cache_length=%d at prefill %d puts the prefill attention-mask ADD at"
+      " %.3f MiB on Qualcomm HTP (2 B x %d heads x %d x %d). Above 1 MiB the"
+      " compiled ADD is not causal: prompts longer than one prefill chunk lose"
+      " their content (LiteRT-LM#3508), and well over the limit even one-chunk"
+      " prompts come out as garbage (the same non-causal-prefill defect,"
+      " litert-torch#1184); %s.",
+      cfg.cache_length, prefill, nbytes / 2**20, heads, prefill,
+      cfg.cache_length + prefill, hint,
+  )

--- a/litert_torch/generative/export_hf/experimental/npu_export/configs/gemma3_270m_qualcomm_sm8850.json
+++ b/litert_torch/generative/export_hf/experimental/npu_export/configs/gemma3_270m_qualcomm_sm8850.json
@@ -10,7 +10,7 @@
   "prefill_lengths": [
     128
   ],
-  "cache_length": 1024,
+  "cache_length": 896,
   "max_calibration_decode_steps": 32,
   "calibration_dataset_format": "jsonl",
   "calibration_eval_task_names": "ALL",

--- a/litert_torch/generative/export_hf/experimental/npu_export/litert_lm_npu_export.ipynb
+++ b/litert_torch/generative/export_hf/experimental/npu_export/litert_lm_npu_export.ipynb
@@ -37,7 +37,7 @@
       "cell_type": "markdown",
       "source": [
         "## 1. Hierarchical Pipeline Configuration\n",
-        "Enter the target **Model ID** (`google/gemma-3-270m-it`, `google/gemma-3-1b-it`, `Qwen/Qwen3-0.6B`), select the **Weight Quantization Recipe** (`dynamic_wi8_afp32`), **Target Vendor** (`qualcomm` or `mediatek`), and type the **Target SoC** chip model in the text box (`sm8850`, `sw6100`, `mt6993`, etc.). The configuration manager dynamically validates the SoC against the authoritative `supported_soc.csv` for that vendor and merges hierarchical defaults (`Vendor -> SoC -> User Overrides`)."
+        "Enter the target **Model ID** (`google/gemma-3-270m-it`, `google/gemma-3-1b-it`, `Qwen/Qwen3-0.6B`), select the **Weight Quantization Recipe** (`dynamic_wi8_afp32`), **Target Vendor** (`qualcomm` or `mediatek`), and type the **Target SoC** chip model in the text box (`sm8850`, `sw6100`, `mt6993`, etc.). The configuration manager dynamically validates the SoC against the authoritative `supported_soc.csv` for that vendor and merges hierarchical defaults (`Vendor -> SoC -> User Overrides`). `cache_length` is bounded on Qualcomm targets by the prefill attention-mask size (`2 B × num_attention_heads × prefill × (cache_length + prefill)` ≤ 1 MiB, see the warning in `build_pipeline_config`); 896 is the largest value at prefill 128 for the 4-head Gemma 3 models (270M, 1B)."
       ],
       "metadata": {}
     },
@@ -57,7 +57,15 @@
         "\n",
         "# Prefill bucket length (tokens). Note: Restricted to 128 due to current NPU runtime limitations.\n",
         "PREFILL_LENGTH = 128  # @param [128]\n",
-        "CACHE_LENGTH = 4096  # @param {type:\"integer\"}\n",
+        "# KV cache capacity (tokens). On Qualcomm HTP keep\n",
+        "#   2 B x num_attention_heads x PREFILL_LENGTH x (CACHE_LENGTH + PREFILL_LENGTH)\n",
+        "# at or under 1 MiB: above it the compiled prefill mask ADD is not causal -\n",
+        "# prompts longer than one prefill chunk lose their content (LiteRT-LM#3508),\n",
+        "# and well over the limit even one-chunk prompts come out as garbage (the\n",
+        "# same non-causal-prefill defect, litert-torch#1184). At prefill 128 that is\n",
+        "# CACHE_LENGTH <= 896 for the 4-head Gemma 3 models (270M, 1B);\n",
+        "# build_pipeline_config warns when a setting crosses it.\n",
+        "CACHE_LENGTH = 896  # @param {type:\"integer\"}\n",
         "\n",
         "# Number of sample prompts (from the 50 randomly generated experimental prompts) to use for calibration.\n",
         "# Note: For production quality, bring your own domain-representative quality-proofed calibration dataset.\n",


### PR DESCRIPTION
I export gemma-3-270m-it and Qwen3-0.6B with the `npu_export` stages for Qualcomm phones. At the shipped presets' value (`cache_length` 1024) both come out wrong on the HTP: gemma-3-270m-it garbles nearly every prompt longer than one prefill chunk (2/20, 0/20, 1/20 on the three two-chunk rows), Qwen3-0.6B produces garbage from the first token. Users of the published Qualcomm bundles hit the same in google-ai-edge/LiteRT-LM#3508, where DenisovAV asked for a note on which `cache_length` is safe. The cause is the size of the prefill attention-mask ADD operand (#1184): the int16 mask tiled over the query heads, `2 B × num_attention_heads × prefill × (cache_length + prefill)`. Above 1 MiB the compiled ADD pairs rows with the wrong operand rows (the row-signature reproducer in #1184: 1,048,576 B passes, 1,081,344 B fails) and prefill is no longer causal.

This PR writes that limit down where `cache_length` is chosen and adds one warning in `build_pipeline_config`. The warning is best effort: it reads `num_attention_heads` from the HF config (`text_config` for the multimodal Gemma 3 configs) and stays silent if that fails. It changes no graph. Two defaults do move, and I am happy to keep either as it is: the notebook's `CACHE_LENGTH` goes from 4096 to 896, and the optional last commit moves the gemma-3-270m preset from 1024 to 896.

What I measured: Galaxy S26 (SM8850 / V81, QAIRT 2.47), compiled on-device, 10–20 prompts per row, same runtime and prompts. The gemma pair is my 2026-09-08 build, the Qwen3 rows one tree (main `6d4c622`); full logs and the scorer are linked below:

| model (heads) | prefill / cache_length | mask ADD operand | short question (13–43 tokens) | filler, then the question (200–230 tokens) |
|---|---|---|---|---|
| gemma-3-270m-it (4), 09-08 | 128 / 896 | 1.000 MiB | — | 18/20 on topic |
| gemma-3-270m-it (4), 09-08 | 128 / 1024 | 1.125 MiB | — | 2/20 |
| Qwen3-0.6B (16) | 128 / 1024 | 4.500 MiB | 0/10 (garbage from the first token) | 0/10 |
| Qwen3-0.6B (16) | 128 / 896 | 4.000 MiB | 0/10 | 0/20 |
| Qwen3-0.6B (16) | 32 / 896 | 0.906 MiB | 3/10 | 10/10 |

The same SRQ graphs decode coherently on the CPU interpreter, so the loss is on the compiled side. The Qwen3 pair does not flip between 896 and 1024 — both are above the line — so the one-variable evidence for the line is the Gemma pair and the #1184 reproducer. The prefill-32 row is only a consistency check, not a recommendation: it changes the graph beyond the mask, and 7 of its 10 short prompts degenerate in a way I have not explained. Other HTP generations are unmeasured here; SM8750 shows the same 896/1024 pair on DenisovAV's FunctionGemma-270m export in LiteRT-LM#3508. I am glad to reshape any of this into whatever form fits the tree.

Links: the row-signature reproducer and the byte line (1,048,576 B pass / 1,081,344 B fail): https://github.com/google-ai-edge/litert-torch/issues/1184 · the runtime-side rows, DenisovAV's SM8750 pair and the same pair on SM8850: https://github.com/google-ai-edge/LiteRT-LM/issues/3508 · per-prompt logs and the scorer: https://gist.github.com/john-rocky/144679e0b9b97d617aad34ed7b3e57de

cc @smilingday
